### PR TITLE
Add shebang to the scripts

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #1st parameter is the backend to use (e.g. make, ninja)
 
 if [ "$1" != "" ]; then

--- a/minimal_bootstrap.sh
+++ b/minimal_bootstrap.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # could also use rdmd like this:
 # rdmd --build-only -version=reggaelib -version=minimal -ofbin/reggae -Isrc -Ipayload -Jpayload/reggae reggaefile.d -b binary .
 # This script doesn't just so it doesn't have to depend on rdmd being available


### PR DESCRIPTION
Otherwise both scripts give errors when being run using different shells

bootstrap.sh uses some bash specific features, so sh is not enough.

