### PR TITLE
Do not display executed commands (make backend)

### DIFF
--- a/payload/reggae/backend/make.d
+++ b/payload/reggae/backend/make.d
@@ -33,6 +33,8 @@ struct Makefile {
         ret ~= ".SUFFIXES:\n"; //disable default rules
         ret ~= options.compilerVariables.join("\n") ~ "\n";
 
+        ret ~= "$(VERBOSE).SILENT:\n"; // Do not display executed commands
+
         foreach(target; build.range) {
 
             mkDir(target);
@@ -46,6 +48,7 @@ struct Makefile {
                     target.implicitsInProjectPath(options.projectPath)).join(" ");
 
             ret ~= " " ~ fileName() ~ "\n";
+	    ret ~= "\t@echo [make] Building " ~ output ~ "\n";
             ret ~= "\t" ~ command(target) ~ "\n";
         }
 


### PR DESCRIPTION
Makes output less verbose:
```
$ make
[Reggae] Writing reggae source files
[Reggae] Writing reggae configuration
[Reggae] Writing dub configuration
[Reggae] Compiling metabuild binary build.o
[Reggae] Compiling metabuild binary buildgen
[Reggae] Running the created binary to generate the build

[make] Building .reggae/objs/reggae.objs/home/gentleman/dev/dlang/reggae/payload/reggae/backend.o
[make] Building .reggae/objs/reggae.objs/home/gentleman/dev/dlang/reggae/payload/reggae.o
[make] Building .reggae/objs/reggae.objs/home/gentleman/dev/dlang/reggae/payload/reggae/core.o
[make] Building .reggae/objs/reggae.objs/home/gentleman/dev/dlang/reggae/src/reggae.o
[make] Building .reggae/objs/reggae.objs/home/gentleman/dev/dlang/reggae/src/reggae/dub.o
[make] Building .reggae/objs/reggae.objs/home/gentleman/dev/dlang/reggae/payload/reggae/rules.o
[make] Building .reggae/objs/reggae.objs/home/gentleman/dev/dlang/reggae/payload/reggae/core/rules.o
[make] Building .reggae/objs/reggae.objs/home/gentleman/dev/dlang/reggae/payload/reggae/dub.o
[make] Building reggae
[make] Building .reggae/objs/ut.objs/home/gentleman/dev/dlang/reggae/bin.o
[make] Building .reggae/objs/ut.objs/home/gentleman/.dub/packages/unit-threaded-0.7.28/unit-threaded/source/unit_threaded.o
[make] Building ut
```

It is still possible to show executed commands by setting `VERBOSE` environment variable:
```
$ make VERBOSE=1
```