### PR TITLE
Fix python crash when re-running reggae.

### DIFF
--- a/src/reggae/reggae.d
+++ b/src/reggae/reggae.d
@@ -152,7 +152,7 @@ private string[] getJsonOutputArgs(in Options options) @safe {
             return jsonVal.toString;
         }();
 
-        return ["/usr/bin/env", "python", "-m", "reggae.reggae_json_build",
+        return ["/usr/bin/env", "python", "-B", "-m", "reggae.reggae_json_build",
                 "--options", optionsString,
                 options.projectPath];
 

--- a/tests/it/runtime/python.d
+++ b/tests/it/runtime/python.d
@@ -54,3 +54,17 @@ unittest {
         ninja.shouldFailToExecute(testPath);
     }
 }
+
+@("Multiple runs will not crash")
+@Tags(["ninja", "json_build", "python"])
+unittest {
+    with(immutable ReggaeSandbox()) {
+        writeFile("reggaefile.py",
+                [`from reggae import *`,
+                 `b = Build(executable(name='app', src_dirs=['src']))`]);
+        writeHelloWorldApp;
+
+        runReggae("-b", "ninja", "-d", "foo=bar");
+        runReggae("-b", "ninja", "-d", "foo=baz");
+    }
+}


### PR DESCRIPTION
On Ubuntu (Windows WSL) with a reggaefile.py and the make backend (nothing else tested), python would crash when re-running reggae to change the value of a user-defined variable with the message `TypeError: compile() expected string without null bytes`. Because the reggaefile.py hadn't changed, python used the .pyc file instead of re-interpreting the .py file, which seems to mess something up.

Adding the -B flag to the python call (available in python 2.6+) prevents the creation of the reggaefile.pyc. An alternative is to `export PYTHONDONTWRITEBYTECODE=1` before calling reggae.