### PR TITLE
Add implicits argument for objectFile/dlangObjectFiles

### DIFF
--- a/payload/reggae/dub/info.d
+++ b/payload/reggae/dub/info.d
@@ -191,7 +191,7 @@ struct DubInfo {
             }
         }
 
-        auto packageTargets = compileFunc()(files, flags, importPaths, stringImportPaths, projDir);
+        auto packageTargets = compileFunc()(files, flags, importPaths, stringImportPaths, [], projDir);
 
         // e.g. /foo/bar -> foo/bar
         const deabsWorkingDir = options.workingDir.deabsolutePath;

--- a/payload/reggae/rules/common.d
+++ b/payload/reggae/rules/common.d
@@ -49,10 +49,11 @@ Target objectFile(in SourceFile srcFile,
                   in Flags flags = Flags(),
                   in ImportPaths includePaths = ImportPaths(),
                   in StringImportPaths stringImportPaths = StringImportPaths(),
+                  Target[] implicits = [],
                   in string projDir = "$project") @safe pure {
 
     auto cmd = compileCommand(srcFile.value, flags.value, includePaths.value, stringImportPaths.value, projDir);
-    return Target(srcFile.value.objFileName, cmd, [Target(srcFile.value)]);
+    return Target(srcFile.value.objFileName, cmd, [Target(srcFile.value)], implicits);
 }
 
 /**

--- a/payload/reggae/rules/d.d
+++ b/payload/reggae/rules/d.d
@@ -81,6 +81,7 @@ Target[] dlangObjectFiles(in string[] srcFiles,
                           in string flags = "",
                           in string[] importPaths = [],
                           in string[] stringImportPaths = [],
+                          Target[] implicits = [],
                           in string projDir = "$project")
     @safe
 {
@@ -93,7 +94,7 @@ Target[] dlangObjectFiles(in string[] srcFiles,
             ? &dlangObjectFilesTogether
             : &dlangObjectFilesPerPackage;
 
-    return func(srcFiles, flags, importPaths, stringImportPaths, projDir);
+    return func(srcFiles, flags, importPaths, stringImportPaths, implicits, projDir);
 }
 
 /// Generate object files for D sources, compiling the whole package together.
@@ -101,6 +102,7 @@ Target[] dlangObjectFilesPerPackage(in string[] srcFiles,
                                     in string flags = "",
                                     in string[] importPaths = [],
                                     in string[] stringImportPaths = [],
+                                    Target[] implicits = [],
                                     in string projDir = "$project")
     @trusted pure
 {
@@ -115,7 +117,8 @@ Target[] dlangObjectFilesPerPackage(in string[] srcFiles,
     }
     return srcFiles.byPackage.map!(a => Target(a[0].packagePath.objFileName,
                                                command(a),
-                                               a.map!(a => Target(a)).array)).array;
+                                               a.map!(a => Target(a)).array,
+                                               implicits)).array;
 }
 
 /// Generate object files for D sources, compiling each module separately
@@ -123,6 +126,7 @@ Target[] dlangObjectFilesPerModule(in string[] srcFiles,
                                    in string flags = "",
                                    in string[] importPaths = [],
                                    in string[] stringImportPaths = [],
+                                   Target[] implicits = [],
                                    in string projDir = "$project")
     @trusted pure
 {
@@ -130,6 +134,7 @@ Target[] dlangObjectFilesPerModule(in string[] srcFiles,
                                          const Flags(flags),
                                          const ImportPaths(importPaths),
                                          const StringImportPaths(stringImportPaths),
+                                         implicits,
                                          projDir)).array;
 }
 
@@ -138,13 +143,14 @@ Target[] dlangObjectFilesTogether(in string[] srcFiles,
                                   in string flags = "",
                                   in string[] importPaths = [],
                                   in string[] stringImportPaths = [],
+                                  Target[] implicits = [],
                                   in string projDir = "$project")
     @trusted pure
 {
 
     if(srcFiles.empty) return [];
     auto command = compileCommand(srcFiles[0], flags, importPaths, stringImportPaths, projDir);
-    return [Target(srcFiles[0].packagePath.objFileName, command, srcFiles.map!(a => Target(a)).array)];
+    return [Target(srcFiles[0].packagePath.objFileName, command, srcFiles.map!(a => Target(a)).array, implicits)];
 }
 
 

--- a/tests/ut/drules.d
+++ b/tests/ut/drules.d
@@ -82,3 +82,18 @@ void testObjectFilesEmpty() {
     dlangObjectFilesPerPackage([]).shouldEqual([]);
     dlangObjectFilesPerModule([]).shouldEqual([]);
 }
+
+void testObjectFilesImplicitTargets() {
+    auto build = Build(dlangObjectFilesPerPackage(["foo.d"],
+                                                  "-O",
+                                                  ["include"],
+                                                  [],
+                                                  [Target("f.json")]));
+
+    build.shouldEqual(Build(Target("foo.o",
+                                   compileCommand("foo.d",
+                                                  "-O",
+                                                  ["include"]),
+                                   [Target("path/to/src/foo.d")],
+                                   [Target("f.json")])));
+}


### PR DESCRIPTION
I have a script that generates some files that are then `import`ed into D. So I needed to have object files implicitly depend on targets. Happy to discuss this change/other approaches.