### PR TITLE
Fix #62 - no object file name clashes when building per package

### DIFF
--- a/payload/reggae/sorting.d
+++ b/payload/reggae/sorting.d
@@ -5,12 +5,15 @@ import std.range: isInputRange;
 
 
 string[][] byPackage(R)(R files) if(isInputRange!R) {
+
     string[][string] packageToFiles;
+
     foreach(file; files) {
         auto package_ = file.filePackage;
         if(package_ !in packageToFiles) packageToFiles[package_] = [];
         packageToFiles[package_] ~= file;
     }
+
     return () @trusted { return packageToFiles.values; }();
 }
 

--- a/tests/it/rules/scriptlike.d
+++ b/tests/it/rules/scriptlike.d
@@ -13,7 +13,7 @@ import tests.it;
                      [Target("d/main.o",
                              compileCommand("d/main.d", "-debug -O", ["d"], ["resources/text"]),
                              [Target("d/main.d")]),
-                      Target("d.o",
+                      Target("d_logger_constants.o",
                              compileCommand("d.d", "-debug -O", ["d"], ["resources/text"]),
                              [Target("d/logger.d"), Target("d/constants.d")]),
                       Target("cpp/maths.o",

--- a/tests/it/rules/static_lib.d
+++ b/tests/it/rules/static_lib.d
@@ -15,7 +15,7 @@ import tests.it;
                              [Target("src/main.d")]),
                       Target("$builddir/maths.a",
                              "ar rcs $out $in",
-                             [Target("libsrc.o",
+                             [Target("libsrc_adder_muler.o",
                                      compileCommand("libsrc.d", "", ["."]),
                                      [Target("libsrc/muler.d"), Target("libsrc/adder.d")]
                                      )]),

--- a/tests/it/runtime/dub.d
+++ b/tests/it/runtime/dub.d
@@ -289,7 +289,7 @@ unittest {
                               "foo.objs",
                               testPath.deabsolutePath,
                               "bar",
-                              "source.o"));
+                              "source_bar.o"));
     }
 }
 
@@ -329,7 +329,7 @@ unittest {
                               testPath.deabsolutePath,
                               "foo.objs",
                               dubNullDir,
-                              "source.o"));
+                              "source_dubnull.o"));
     }
 }
 

--- a/tests/it/runtime/issues.d
+++ b/tests/it/runtime/issues.d
@@ -30,7 +30,6 @@ unittest {
 }
 
 
-@ShouldFail
 @("62")
 @Tags(["dub", "make"])
 unittest {

--- a/tests/ut/rules/dub.d
+++ b/tests/ut/rules/dub.d
@@ -59,7 +59,7 @@ unittest {
 
     string[] empty;
 
-    auto compileTarget = Target("source/luad.o",
+    auto compileTarget = Target("source/luad_foo.o",
                                 Command(CommandType.compile,
                                         assocList(
                                              [
@@ -82,7 +82,7 @@ unittest {
     options.dCompiler = "dmd";
     options.projectPath = "/proj";
     actual.shellCommand(options).split(" ").filter!(a => a != "").
-        shouldEqual(["dmd", "-ofapp", "-m64", "source/luad.o", "$LIB/liblua.a"]);
+        shouldEqual(["dmd", "-ofapp", "-m64", "source/luad_foo.o", "$LIB/liblua.a"]);
 }
 
 
@@ -103,7 +103,7 @@ unittest {
     string[] empty;
     const expected = Target("$builddir/libfoo.a",
                             Command("ar rcs $out $in"),
-                            [Target("path/myapp/src.o",
+                            [Target("path/myapp/src_file1_file2.o",
                                     Command(CommandType.compile,
                                             assocList([
                                                           assocEntry("includes", ["-I/leproj"]),
@@ -133,7 +133,7 @@ unittest {
     const expected = Target("libfoo.a",
                             Command(CommandType.link, assocList([assocEntry("flags", ["-m64"])])),
                             [
-                                Target("path/myapp/src.o",
+                                Target("path/myapp/src_file1_file2.o",
                                        Command(CommandType.compile,
                                                assocList([
                                                              assocEntry("includes", ["-I/leproj"]),


### PR DESCRIPTION
Before, when trying to depend on arsd-official, every subpackage
ended up with the same object file name since they're all in
the same directory. Now the package name is used but so are all
the module names in the package being built to avoid this.