### PR TITLE
Mimic how dub builds static library dependencies

### DIFF
--- a/payload/reggae/dub/info.d
+++ b/payload/reggae/dub/info.d
@@ -192,11 +192,12 @@ struct DubInfo {
             import reggae.rules.d: dlangStaticLibraryTogether;
             import reggae.config: options;
 
-            const staticLib =
+            const isStaticLibDep =
                 dubPackage.targetType == TargetType.staticLibrary &&
-                options.dubStaticLibInsteadOfObjs;
+                dubPackageIndex != 0 &&
+                !options.dubDepObjsInsteadOfStaticLib;
 
-            return staticLib
+            return isStaticLibDep
                 ? &dlangStaticLibraryTogether
                 : compileFunc;
         }

--- a/payload/reggae/dub/info.d
+++ b/payload/reggae/dub/info.d
@@ -188,38 +188,17 @@ struct DubInfo {
             }
         }
 
-        Target[] compileToStaticLib(
-            in string[] srcFiles,
-            in string flags,
-            in string[] importPaths,
-            in string[] stringImportPaths,
-            Target[] implicits,
-            in string projDir
-            )
-        {
-            // dub builds static library dependencies by calling dmd
-            // -lib on all the source files. dmd in turn has its own
-            // code to produce static libraries instead of calling
-            // an external tool, and this can affect linker outcomes.
-            return dlangObjectFilesTogether(
-                srcFiles,
-                "-lib " ~ flags,
-                importPaths,
-                stringImportPaths,
-                implicits,
-                projDir,
-            );
-        }
-
         auto targetsFunc() {
+            import reggae.rules.d: dlangStaticLibraryTogether;
             import reggae.config: options;
-            import std.functional: toDelegate;
 
-            const staticLib = dubPackage.targetType == TargetType.staticLibrary &&
+            const staticLib =
+                dubPackage.targetType == TargetType.staticLibrary &&
                 options.dubStaticLibInsteadOfObjs;
+
             return staticLib
-                ? &compileToStaticLib
-                : () @trusted { return compileFunc.toDelegate; }();
+                ? &dlangStaticLibraryTogether
+                : compileFunc;
         }
 
         auto packageTargets = targetsFunc()(files, flags, importPaths, stringImportPaths, [], projDir);

--- a/payload/reggae/options.d
+++ b/payload/reggae/options.d
@@ -48,7 +48,7 @@ struct Options {
     bool dubLocalPackages;
     string[] dependencies;
     string dubObjsDir;
-    bool dubStaticLibInsteadOfObjs;
+    bool dubDepObjsInsteadOfStaticLib;
 
     version(Windows)
         DubArchitecture dubArch = DubArchitecture.x86;
@@ -241,7 +241,7 @@ Options getOptions(Options defaultOptions, string[] args) @trusted {
             "dub_local", "Project uses dub local packages", &options.dubLocalPackages,
             "dub-objs-dir", "Directory to place object files for dub dependencies", &options.dubObjsDir,
             "dub-arch", "Architecture (x86, x86_64, x86_mscoff)", &options.dubArch,
-            "dub-static-lib-deps", "Use a static library for dub dependencies", &options.dubStaticLibInsteadOfObjs,
+            "dub-deps-objs", "Use object files instead of static library for dub dependencies", &options.dubDepObjsInsteadOfStaticLib,
         );
 
         if(helpInfo.helpWanted) {

--- a/payload/reggae/rules/common.d
+++ b/payload/reggae/rules/common.d
@@ -348,6 +348,15 @@ version(Windows) {
 }
 
 string objFileName(in string srcFileName) @safe pure {
+    return extFileName(srcFileName, objExt);
+}
+
+string libFileName(in string srcFileName) @safe pure {
+    return extFileName(srcFileName, libExt);
+}
+
+
+string extFileName(in string srcFileName, in string extension) @safe pure {
     import reggae.path: deabsolutePath;
     import std.path: stripExtension;
     import std.array: replace;
@@ -357,8 +366,9 @@ string objFileName(in string srcFileName) @safe pure {
         .stripExtension
         ;
 
-    return (tmp ~ objExt).replace("..", "__");
+    return (tmp ~ extension).replace("..", "__");
 }
+
 
 string removeProjectPath(in string path) @safe {
     import std.path: relativePath, absolutePath;

--- a/payload/reggae/rules/d.d
+++ b/payload/reggae/rules/d.d
@@ -162,18 +162,67 @@ Target[] dlangObjectFilesTogether(in string[] srcFiles,
                                   in string[] stringImportPaths = [],
                                   Target[] implicits = [],
                                   in string projDir = "$project")
-    @trusted pure
+    @safe pure
 {
-    import reggae.rules.common: objFileName, libFileName;
-    import std.algorithm.searching: canFind;
-    import std.algorithm.iteration: splitter;
-    import std.array: join;
-    import std.path: stripExtension, baseName;
-    import std.range: take;
+    import reggae.rules.common: objFileName;
+    return dlangTargetTogether(
+        &objFileName,
+        srcFiles,
+        flags,
+        importPaths,
+        stringImportPaths,
+        implicits,
+        projDir
+    );
+}
 
+
+/**
+   Generate a static library for D sources, compiling all of them together.
+   With dmd, this results in a different static library than compiling the
+   source into object files then using `ar` to create the .a.
+*/
+Target[] dlangStaticLibraryTogether(in string[] srcFiles,
+                                    in string flags = "",
+                                    in string[] importPaths = [],
+                                    in string[] stringImportPaths = [],
+                                    Target[] implicits = [],
+                                    in string projDir = "$project")
+    @safe pure
+{
+    import reggae.rules.common: libFileName;
+    return dlangTargetTogether(
+        &libFileName,
+        srcFiles,
+        "-lib " ~ flags,
+        importPaths,
+        stringImportPaths,
+        implicits,
+        projDir
+    );
+}
+
+
+private Target[] dlangTargetTogether(
+    string function(in string) @safe pure toFileName,
+    in string[] srcFiles,
+    in string flags = "",
+    in string[] importPaths = [],
+    in string[] stringImportPaths = [],
+    Target[] implicits = [],
+    in string projDir = "$project",
+    )
+    @safe pure
+{
     if(srcFiles.empty) return [];
 
-    string outputFileName() {
+    // when building a .o or .a for multiple source files, this generates a name
+    // designed to avoid filename clashes (see arsd-official)
+    string outputNameForSrcFiles() @safe pure {
+        import reggae.sorting: packagePath;
+        import std.array: join;
+        import std.path: stripExtension, baseName;
+        import std.range: take;
 
         // then number in `take` is arbitrary but larger than 1 to try to get
         // unique file names without making the file name too long.
@@ -182,15 +231,20 @@ Target[] dlangObjectFilesTogether(in string[] srcFiles,
             .map!baseName
             .map!stripExtension
             .join("_")
+
             ~ ".d";
-        const path = packagePath(srcFiles[0]) ~ "_" ~ name;
-        const isStaticLibrary = flags.splitter(" ").canFind("-lib");
-        return isStaticLibrary ? libFileName(path) : objFileName(path);
+        return packagePath(srcFiles[0]) ~ "_" ~ name;
     }
 
+    const outputFileName = toFileName(outputNameForSrcFiles);
     auto command = compileCommand(srcFiles[0], flags, importPaths, stringImportPaths, projDir);
+
     return [Target(outputFileName, command, srcFiles.map!(a => Target(a)).array, implicits)];
 }
+
+
+
+
 
 
 /**

--- a/tests/it/buildgen/optional.d
+++ b/tests/it/buildgen/optional.d
@@ -6,6 +6,7 @@ import std.file;
 
 
 @("optional")
+@Flaky
 @Values("ninja", "make", "binary")
 unittest {
 

--- a/tests/it/runtime/dub.d
+++ b/tests/it/runtime/dub.d
@@ -279,7 +279,7 @@ unittest {
         });
 
         const dubObjsDir = buildPath(testPath, "objsdir");
-        const output = runReggae("-b", "ninja", "--dub-objs-dir=" ~ dubObjsDir);
+        const output = runReggae("-b", "ninja", "--dub-objs-dir=" ~ dubObjsDir, "--dub-deps-objs");
         writelnUt(output);
         ninja.shouldExecuteOk;
 
@@ -292,6 +292,7 @@ unittest {
                               "source_bar.o"));
     }
 }
+
 
 @("dub objs option registry dependency")
 @Tags("dub", "ninja", "dubObjsDir")
@@ -318,7 +319,7 @@ unittest {
         });
 
         const dubObjsDir = buildPath(testPath, "objsdir");
-        const output = runReggae("-b", "ninja", "--dub-objs-dir=" ~ dubObjsDir);
+        const output = runReggae("-b", "ninja", "--dub-objs-dir=" ~ dubObjsDir, "--dub-deps-objs");
         writelnUt(output);
 
         ninja.shouldExecuteOk;
@@ -741,7 +742,7 @@ unittest {
             int twice(int i) { return i * 2; }
         });
 
-        runReggae("-b", "ninja", "--dub-static-lib-deps");
+        runReggae("-b", "ninja");
         ninja.shouldExecuteOk;
         shouldFail("ut");
     }

--- a/tests/it/runtime/dub.d
+++ b/tests/it/runtime/dub.d
@@ -736,7 +736,11 @@ unittest {
                 writeln(3.twice);
             }
         });
-        writeFile("source/oops.d", "module oops; int twice(int i) { return i * 2; }");
+        writeFile("source/oops.d", q{
+            module oops;
+            int twice(int i) { return i * 2; }
+        });
+
         runReggae("-b", "ninja", "--dub-static-lib-deps");
         ninja.shouldExecuteOk;
         shouldFail("ut");


### PR DESCRIPTION
dub build static library dependencies by calling `dmd -lib` on the source files instead of compiling to object files first then calling the archiver. This results in different outputs and different behaviour which can manifest as linker errors. Using dmd's internal archiver, for some reason, seems to produce more lenient binaries that don't complain as much about duplicate or missing symbols.

Fixes #91 and #92.