### PR TITLE
dcompile: Avoid importing std.regex

### DIFF
--- a/payload/reggae/dependencies.d
+++ b/payload/reggae/dependencies.d
@@ -2,24 +2,45 @@ module reggae.dependencies;
 
 
 /**
+ * Given a line from verbose compiler output, checks if it is an import
+ * of a non-druntime/Phobos module and returns its file path in that case.
+ * Otherwise, returns null.
+ */
+string tryExtractPathFromImportLine(in string line) @safe pure {
+    import std.algorithm: any;
+    import std.string: indexOf, startsWith, strip;
+
+    // looking for: `import <whitespace(s)> <moduleID> <whitespace(s)> (<filePath>)`
+    if (!(line.startsWith("import ") && line[$-1] == ')'))
+        return null;
+
+    const rest = line[7 .. $];
+    const i = rest.indexOf('(');
+    if (i <= 0)
+        return null;
+
+    const id = strip(rest[0 .. i-1]);
+    static immutable exclPrefixes = ["std.", "core.", "etc.", "ldc."];
+    if (id == "object" || exclPrefixes.any!(p => id.startsWith(p)))
+        return null;
+
+    return rest[i+1 .. $-1];
+}
+
+/**
  * Given the output of compiling a file, return
  * the list of D files to compile to link the executable.
  * Only includes source files to compile
  */
-string[] dMainDepSrcs()(in string output) {
-    import std.regex: regex, matchFirst;
+string[] dMainDepSrcs(in string output) {
     import std.string: splitLines;
 
     string[] dependencies;
-    auto importReg = regex(`^import +([^\t]+)[\t\s]+\((.+)\)$`);
-    auto stdlibReg = regex(`^(std\.|core\.|etc\.|ldc\.|object$)`);
 
     foreach(line; output.splitLines) {
-        auto importMatch = line.matchFirst(importReg);
-        if(importMatch) {
-            auto stdlibMatch = importMatch.captures[1].matchFirst(stdlibReg);
-            if(!stdlibMatch) dependencies ~= importMatch.captures[2];
-        }
+        const importPath = tryExtractPathFromImportLine(line);
+        if (importPath !is null)
+            dependencies ~= importPath;
     }
 
     return dependencies;


### PR DESCRIPTION
On my (fast) Linux box, this brings the build time for the `dcompile` executable down from ~1.35 secs to ~0.6 secs with DMD v2.094.2.
For reggae itself, this means a decrease from 3.6 to 2.9 secs for the 'metabuild' stage (before invoking make).

While at it, perform the -v output parsing of `import` and `file` lines in a single pass.