### PR TITLE
Ninja: Remove superfluous DEPFILE parameter for build statements

### DIFF
--- a/payload/reggae/backend/ninja.d
+++ b/payload/reggae/backend/ninja.d
@@ -228,6 +228,8 @@ private:
         string[] paramLines;
 
         foreach(immutable param; target.commandParamNames) {
+            // skip the DEPFILE parameter, it's already specified in the rule
+            if (param == "DEPFILE") continue;
             immutable value = target.getCommandParams(_projectPath, param, []).join(" ");
             if(value == "") continue;
             paramLines ~= param ~ " = " ~ value.escapeEnvVars;

--- a/tests/ut/cpprules.d
+++ b/tests/ut/cpprules.d
@@ -14,7 +14,7 @@ void testNoIncludePaths() {
     enum objPath = buildPath("path/to/src/foo" ~ objExt);
     ninja.buildEntries.shouldEqual(
         [NinjaEntry("build " ~ objPath ~ ": _cppcompile " ~ buildPath("/tmp/myproject/path/to/src/foo.cpp"),
-                    ["DEPFILE = " ~ objPath ~ ".dep"]),
+                    []),
             ]);
 }
 
@@ -26,8 +26,7 @@ void testIncludePaths() {
     enum objPath = buildPath("path/to/src/foo" ~ objExt);
     ninja.buildEntries.shouldEqual(
         [NinjaEntry("build " ~ objPath ~ ": _cppcompile " ~ buildPath("/tmp/myproject/path/to/src/foo.cpp"),
-                    ["includes = -I" ~buildPath("/tmp/myproject/path/to/src") ~ " -I" ~ buildPath("/tmp/myproject/other/path"),
-                     "DEPFILE = " ~ objPath ~ ".dep"]),
+                    ["includes = -I" ~buildPath("/tmp/myproject/path/to/src") ~ " -I" ~ buildPath("/tmp/myproject/other/path")]),
             ]);
 }
 
@@ -38,8 +37,7 @@ void testFlagsCompileC() {
     enum objPath = buildPath("path/to/src/foo" ~ objExt);
     ninja.buildEntries.shouldEqual(
         [NinjaEntry("build " ~ objPath ~ ": _ccompile " ~ buildPath("/tmp/myproject/path/to/src/foo.c"),
-                    ["flags = -m64 -fPIC -O3",
-                     "DEPFILE = " ~ objPath ~ ".dep"]),
+                    ["flags = -m64 -fPIC -O3"]),
             ]);
 }
 
@@ -49,8 +47,7 @@ void testFlagsCompileCpp() {
     enum objPath = buildPath("path/to/src/foo" ~ objExt);
     ninja.buildEntries.shouldEqual(
         [NinjaEntry("build " ~ objPath ~ ": _cppcompile " ~ buildPath("/tmp/myproject/path/to/src/foo.cpp"),
-                    ["flags = -m64 -fPIC -O3",
-                     "DEPFILE = " ~ objPath ~ ".dep"]),
+                    ["flags = -m64 -fPIC -O3"]),
             ]);
 }
 

--- a/tests/ut/drules.d
+++ b/tests/ut/drules.d
@@ -16,7 +16,7 @@ void testDCompileNoIncludePathsNinja() {
     enum objPath = buildPath("path/to/src/foo" ~ objExt);
     ninja.buildEntries.shouldEqual(
         [NinjaEntry("build " ~ objPath ~ ": _dcompile " ~ buildPath("/tmp/myproject/path/to/src/foo.d"),
-                    ["DEPFILE = " ~ objPath ~ ".dep"])]);
+                    [])]);
 }
 
 
@@ -29,8 +29,7 @@ void testDCompileIncludePathsNinja() {
     ninja.buildEntries.shouldEqual(
         [NinjaEntry("build " ~ objPath ~ ": _dcompile " ~ buildPath("/tmp/myproject/path/to/src/foo.d"),
                     ["includes = -I" ~ buildPath("/tmp/myproject/path/to/src") ~ " -I" ~ buildPath("/tmp/myproject/other/path"),
-                     "flags = -O",
-                     "DEPFILE = " ~ objPath ~ ".dep"])]);
+                     "flags = -O"])]);
 }
 
 void testDCompileIncludePathsMake() {


### PR DESCRIPTION
`depfile` is already specified in the relevant default rules (and set to `$out.dep`).