### PR TITLE
Ninja: Add descriptions for default rules

### DIFF
--- a/tests/it/runtime/dub.d
+++ b/tests/it/runtime/dub.d
@@ -17,7 +17,7 @@ unittest {
         shouldNotExist("reggaefile.d");
         writelnUt("\n\nReggae output:\n\n", runReggae("-b", "ninja").lines.join("\n"), "-----\n");
         shouldExist("reggaefile.d");
-        auto output = ninja.shouldExecuteOk;
+        auto output = ninja(["-v"]).shouldExecuteOk;
 
         version(Windows) {
             // args in response file
@@ -868,7 +868,7 @@ unittest {
         );
 
         runReggae("-b", "ninja", "--dub-build-type=release");
-        const buildLines = ninja.shouldExecuteOk;
+        const buildLines = ninja(["-v"]).shouldExecuteOk;
 
         version(Windows) {
             // args in response file

--- a/tests/ut/ninja.d
+++ b/tests/ut/ninja.d
@@ -161,19 +161,23 @@ void testDefaultRules() {
                        ? ["command = cl.exe @$out.rsp",
                           "rspfile = $out.rsp",
                           "rspfile_content = /nologo $flags $includes /showIncludes /Fo$out -c $in",
-                          "deps = msvc"]
+                          "deps = msvc",
+                          "description = Compiling $out"]
                        : ["command = gcc $flags $includes -MMD -MT $out -MF $out.dep -o $out -c $in",
                           "deps = gcc",
-                          "depfile = $out.dep"]),
+                          "depfile = $out.dep",
+                          "description = Compiling $out"]),
             NinjaEntry("rule _cppcompile",
                        isWindows
                        ? ["command = cl.exe @$out.rsp",
                           "rspfile = $out.rsp",
                           "rspfile_content = /nologo $flags $includes /showIncludes /Fo$out -c $in",
-                          "deps = msvc"]
+                          "deps = msvc",
+                          "description = Compiling $out"]
                        : ["command = g++ $flags $includes -MMD -MT $out -MF $out.dep -o $out -c $in",
                           "deps = gcc",
-                          "depfile = $out.dep"]),
+                          "depfile = $out.dep",
+                          "description = Compiling $out"]),
             NinjaEntry("rule _dcompile",
                        isWindows
                        ? ["command = " ~ buildPath(".reggae/dcompile") ~ " @$out.rsp",
@@ -181,49 +185,62 @@ void testDefaultRules() {
                           "rspfile_content = --objFile=$out --depFile=$out.dep dmd" ~
                               defaultDCModel ~ " $flags $includes $stringImports $in",
                           "deps = gcc",
-                          "depfile = $out.dep"]
+                          "depfile = $out.dep",
+                          "description = Compiling $out"]
                        : ["command = " ~ buildPath(".reggae/dcompile") ~ " --objFile=$out --depFile=$out.dep dmd" ~
                               defaultDCModel ~ " $flags $includes $stringImports $in",
                           "deps = gcc",
-                          "depfile = $out.dep"]),
+                          "depfile = $out.dep",
+                          "description = Compiling $out"]),
             NinjaEntry("rule _clink",
                        isWindows
                        ? ["command = cl.exe @$out.rsp",
                           "rspfile = $out.rsp",
-                          "rspfile_content = /nologo /Fo$out $flags $in"]
-                       : ["command = gcc -o $out $flags $in"]),
+                          "rspfile_content = /nologo /Fo$out $flags $in",
+                          "description = Linking $out"]
+                       : ["command = gcc -o $out $flags $in",
+                          "description = Linking $out"]),
             NinjaEntry("rule _cpplink",
                        isWindows
                        ? ["command = cl.exe @$out.rsp",
                           "rspfile = $out.rsp",
-                          "rspfile_content = /nologo /Fo$out $flags $in"]
-                       : ["command = g++ -o $out $flags $in"]),
+                          "rspfile_content = /nologo /Fo$out $flags $in",
+                          "description = Linking $out"]
+                       : ["command = g++ -o $out $flags $in",
+                          "description = Linking $out"]),
             NinjaEntry("rule _dlink",
                        isWindows
                        ? ["command = dmd @$out.rsp",
                           "rspfile = $out.rsp",
-                          "rspfile_content =" ~ defaultDCModel ~ " -of$out $flags $in"]
-                       : ["command = dmd" ~ defaultDCModel ~ " -of$out $flags $in"]),
+                          "rspfile_content =" ~ defaultDCModel ~ " -of$out $flags $in",
+                          "description = Linking $out"]
+                       : ["command = dmd" ~ defaultDCModel ~ " -of$out $flags $in",
+                          "description = Linking $out"]),
             NinjaEntry("rule _ulink",
-                       ["command = dmd" ~ defaultDCModel ~ " -of$out $flags $in"]),
+                       ["command = dmd" ~ defaultDCModel ~ " -of$out $flags $in",
+                        "description = Linking $out"]),
             NinjaEntry("rule _ccompileAndLink",
                        isWindows
                        ? ["command = cl.exe @$out.rsp",
                           "rspfile = $out.rsp",
                           "rspfile_content = /nologo $flags $includes /showIncludes /Fo$out $in",
-                          "deps = msvc"]
+                          "deps = msvc",
+                          "description = Building $out"]
                        : ["command = gcc $flags $includes -MMD -MT $out -MF $out.dep -o $out $in",
                           "deps = gcc",
-                          "depfile = $out.dep"]),
+                          "depfile = $out.dep",
+                          "description = Building $out"]),
             NinjaEntry("rule _cppcompileAndLink",
                        isWindows
                        ? ["command = cl.exe @$out.rsp",
                           "rspfile = $out.rsp",
                           "rspfile_content = /nologo $flags $includes /showIncludes /Fo$out $in",
-                          "deps = msvc"]
+                          "deps = msvc",
+                          "description = Building $out"]
                        : ["command = g++ $flags $includes -MMD -MT $out -MF $out.dep -o $out $in",
                           "deps = gcc",
-                          "depfile = $out.dep"]),
+                          "depfile = $out.dep",
+                          "description = Building $out"]),
             NinjaEntry("rule _dcompileAndLink",
                        isWindows
                        ? ["command = " ~ buildPath(".reggae/dcompile") ~ " @$out.rsp",
@@ -231,11 +248,13 @@ void testDefaultRules() {
                           "rspfile_content = --objFile=$out --depFile=$out.dep dmd" ~
                               defaultDCModel ~ " $flags $includes $stringImports $in",
                           "deps = gcc",
-                          "depfile = $out.dep"]
+                          "depfile = $out.dep",
+                          "description = Building $out"]
                        : ["command = " ~ buildPath(".reggae/dcompile") ~ " --objFile=$out --depFile=$out.dep dmd" ~
                               defaultDCModel ~ " $flags $includes $stringImports $in",
                           "deps = gcc",
-                          "depfile = $out.dep"]),
+                          "depfile = $out.dep",
+                          "description = Building $out"]),
 
             NinjaEntry("rule _phony",
                        ["command = $cmd"]),
@@ -251,10 +270,12 @@ void testDefaultRulesWeirdCCompiler() {
                             ? ["command = weirdcc @$out.rsp",
                                "rspfile = $out.rsp",
                                "rspfile_content = /nologo $flags $includes /showIncludes /Fo$out -c $in",
-                               "deps = msvc"]
+                               "deps = msvc",
+                               "description = Compiling $out"]
                             : ["command = weirdcc $flags $includes -MMD -MT $out -MF $out.dep -o $out -c $in",
                                "deps = gcc",
-                               "depfile = $out.dep"]);
+                               "depfile = $out.dep",
+                               "description = Compiling $out"]);
     entry.shouldBeIn(rules);
 }
 


### PR DESCRIPTION
Mimicking `make` (which displays `Building $out`) instead of having Ninja show the command line (usually, some `.reggae/dcompile ...`).
[`ninja -v` can be used to show the invoked commands.]