### PR TITLE
dcompile: Escape spaces in paths in generated .dep files

### DIFF
--- a/payload/reggae/dcompile.d
+++ b/payload/reggae/dcompile.d
@@ -231,10 +231,13 @@ string[] dMainDependencies(in string output) @safe {
 
 
 string[] dependenciesToFile(in string objFile, in string[] deps) @safe pure nothrow {
-    import std.array: join;
+    import std.array: join, replace;
+    static string escape(string arg) {
+        return arg.replace(" ", `\ `); // TODO: there'd be more...
+    }
     return [
-        objFile ~ ": \\",
-        deps.join(" "),
+        escape(objFile) ~ ": \\",
+        deps.map!escape.join(" "),
     ];
 }
 


### PR DESCRIPTION
This seems to be enough for proper deps on Windows (tested with ninja).