### PR TITLE
Significantly shorten object file/lib paths for dub dependencies (mainly for Windows)

### DIFF
--- a/payload/reggae/backend/ninja.d
+++ b/payload/reggae/backend/ninja.d
@@ -357,6 +357,12 @@ private:
                 if(line.canFind(dep)) {
                     line = line.replace(dep, "$in");
                     input = dep;
+                } else version(Windows) {
+                    const dep_fwd = dep.replace(`\`, "/");
+                    if(line.canFind(dep_fwd)) {
+                        line = line.replace(dep_fwd, "$in");
+                        input = dep;
+                    }
                 }
             }
             return line;

--- a/payload/reggae/path.d
+++ b/payload/reggae/path.d
@@ -13,7 +13,7 @@ string buildPath(scope string[] segments...) @safe pure nothrow {
     return r;
 }
 
-string deabsolutePath(in string path) @safe pure {
+string deabsolutePath(in string path) @safe pure nothrow {
     import std.path: isRooted, stripDrive;
     return path.isRooted
         ? path.stripDrive[1..$]

--- a/payload/reggae/rules/c_and_cpp.d
+++ b/payload/reggae/rules/c_and_cpp.d
@@ -22,7 +22,7 @@ Target unityBuild(ExeName exeName,
 
     const srcFiles = sourcesToFileNames!(sourcesFunc);
 
-    immutable dirName = buildPath(options.workingDir, topLevelDirName(Target(exeName.value)));
+    immutable dirName = buildPath(options.workingDir, objDirOf(Target(exeName.value)));
     dirName.exists || mkdirRecurse(dirName);
 
     immutable fileName = buildPath(dirName, "unity.cpp");
@@ -87,7 +87,7 @@ Target unityTarget(R1, R2)(in ExeName exeName,
     import std.algorithm;
 
     auto justFileName = srcFiles.map!getLanguage.front == Language.C ? "unity.c" : "unity.cpp";
-    auto unityFileName = buildPath(gBuilddir, topLevelDirName(Target(exeName.value)), justFileName);
+    auto unityFileName = buildPath(gBuilddir, objDirOf(Target(exeName.value)), justFileName);
     auto command = compileCommand(unityFileName,
                                    flags.value,
                                    includes.value,

--- a/payload/reggae/rules/common.d
+++ b/payload/reggae/rules/common.d
@@ -392,9 +392,7 @@ Command compileCommand(in string srcFileName,
 {
 
     string maybeExpand(string path) {
-        return path.startsWith(gBuilddir)
-            ? buildPath(expandBuildDir(path))
-            : buildPath(projDir, path);
+        return expandOutput(path, projDir, projDir);
     }
 
     auto includeParams = includePaths.map!(a => "-I" ~ maybeExpand(a)). array;

--- a/payload/reggae/rules/dub.d
+++ b/payload/reggae/rules/dub.d
@@ -330,9 +330,9 @@ static if(isDubProject) {
 
         // otherwise the target wouldn't be top-level in the presence of
         // postBuildCommands
-        auto ret =  dubInfo.postBuildCommands == ""
+        auto ret = dubInfo.postBuildCommands == ""
             ? path
-            : buildPath("$project", path);
+            : buildPath("$builddir", path);
 
         return ret == "" ? "placeholder" : ret;
     }

--- a/src/reggae/reggae.d
+++ b/src/reggae/reggae.d
@@ -15,7 +15,6 @@ module reggae.reggae;
 import std.stdio;
 import std.process: execute, environment;
 import std.array: array, join, empty, split;
-import std.path: absolutePath, relativePath;
 import std.typetuple;
 import std.file;
 import std.conv: text;

--- a/tests/ut/backend/binary.d
+++ b/tests/ut/backend/binary.d
@@ -51,12 +51,18 @@ import tests.utils;
 }
 
 @("Top-level targets") unittest {
+    import reggae.path: buildPath;
+
     auto foo = Target("foo", "", Target("foo.d"));
     auto bar = Target("bar", "", Target("bar.d"));
     auto binary = Binary(Build(foo, bar), Options());
-    binary.topLevelTargets(["foo"]).shouldEqual([foo]);
-    binary.topLevelTargets(["bar"]).shouldEqual([bar]);
-    binary.topLevelTargets([]).shouldEqual([foo, bar]);
+
+    auto newFoo = Target("foo", "", Target(buildPath("$project/foo.d")));
+    auto newBar = Target("bar", "", Target(buildPath("$project/bar.d")));
+
+    binary.topLevelTargets(["foo"]).shouldEqual([newFoo]);
+    binary.topLevelTargets(["bar"]).shouldEqual([newBar]);
+    binary.topLevelTargets([]).shouldEqual([newFoo, newBar]);
     binary.topLevelTargets(["oops"]).shouldBeEmpty;
 }
 

--- a/tests/ut/ninja.d
+++ b/tests/ut/ninja.d
@@ -394,10 +394,10 @@ else
     auto foo = Target("$project/foodir", "mkdir -p $out", emptyDependencies, [stuff]);
     auto ninja = Ninja(Build(foo), "/path/to/proj"); //to make sure we can
     ninja.buildEntries.shouldEqual(
-        [NinjaEntry(buildPath("build .reggae/objs//path/to/proj/foodir.objs/foo.o: dmd /path/to/proj/foo.d"),
+        [NinjaEntry(buildPath("build .reggae/objs/__project__/foodir.objs/foo.o: dmd /path/to/proj/foo.d"),
                     ["before = -of",
                      "between = -c"]),
-         NinjaEntry(buildPath("build /path/to/proj/foodir: mkdir  | .reggae/objs//path/to/proj/foodir.objs/foo.o"),
+         NinjaEntry(buildPath("build /path/to/proj/foodir: mkdir  | .reggae/objs/__project__/foodir.objs/foo.o"),
                     ["before = -p"]),
             ]);
     ninja.ruleEntries.shouldEqual(


### PR DESCRIPTION
I don't have the full picture of all these path manipulations, but started working on it and tried to simplify it. The basic assumption is that relative paths in reggaefile.d are relative to the project dir, and that those in generated Makefiles and ninja scripts are relative to the build dir.

The dub paths are transformed like this:
```
.reggae\objs\ut.exe.objs\Users\IEUser\AppData\Local\dub\packages\unit-threaded-1.0.11\unit-threaded\source\unit_threaded_attrs_io_light_package.lib
=>
.reggae\objs\ut.exe.objs\__dub__\unit-threaded\source\unit_threaded_attrs_io_light_package.lib
```