### PR TITLE
[WIP] Fix #151

### DIFF
--- a/src/reggae/dub/interop/package.d
+++ b/src/reggae/dub/interop/package.d
@@ -104,19 +104,22 @@ private from!"reggae.dub.info".DubInfo getDubInfo
         auto settings = dub.getGeneratorSettings(options);
         const configs = dubConfigurations(output, dub, options, settings);
         bool atLeastOneConfigOk;
+        string someValidConfig;
         Exception dubInfoFailure;
 
         foreach(config; configs.configurations) {
             try {
                 handleDubConfig(output, dub, options, settings, config);
                 atLeastOneConfigOk = true;
+                someValidConfig = config;
             } catch(Exception ex) {
                 output.log("ERROR: Could not get info for configuration ", config, ": ", ex.msg);
                 if(dubInfoFailure is null) dubInfoFailure = ex;
             }
         }
 
-        gDubInfos["default"] = gDubInfos[configs.default_];
+        const cfg = (configs.default_ in gDubInfos) ? configs.default_ : someValidConfig;
+        gDubInfos["default"] = gDubInfos[cfg];
 
         if(!atLeastOneConfigOk) {
             assert(dubInfoFailure !is null,

--- a/tests/it/runtime/dub.d
+++ b/tests/it/runtime/dub.d
@@ -860,13 +860,11 @@ unittest {
 
             configuration "library" {
                 targetType  "sourceLibrary"
-                targetName  "Library"
                 sourceFiles "source/library.d"
             }
 
             configuration "demo" {
                 targetType "executable"
-                targetName "demo"
                 sourceFiles "source/demo.d"
             }
         `);
@@ -886,7 +884,7 @@ unittest {
 
         runReggae("-b", "ninja");
         ninja(["default", "ut"]).shouldExecuteOk;
-        shouldFail("ut");
+        shouldSucceed("ut");
     }
 }
 

--- a/tests/it/runtime/dub.d
+++ b/tests/it/runtime/dub.d
@@ -850,6 +850,47 @@ unittest {
 }
 
 
+@("configurations_where_default_is_source_lib")
+@Tags(["dub", "ninja"])
+unittest {
+    with(immutable ReggaeSandbox()) {
+        writeFile("dub.sdl", `
+            name "dub_default_config_is_source_library"
+            description "Test for issue 151"
+
+            configuration "library" {
+                targetType  "sourceLibrary"
+                targetName  "Library"
+                sourceFiles "source/library.d"
+            }
+
+            configuration "demo" {
+                targetType "executable"
+                targetName "demo"
+                sourceFiles "source/demo.d"
+            }
+        `);
+        writeFile("library.d", q{
+            module library;
+        });
+        writeFile("source/demo.d", q{
+            import std.stdio;
+
+            version(unittest) {}
+            else
+            void main()
+            {
+                writeln("Test for issue 151.");
+            }
+        });
+
+        runReggae("-b", "ninja");
+        ninja(["default", "ut"]).shouldExecuteOk;
+        shouldFail("ut");
+    }
+}
+
+
 @("buildtype.release")
 @Tags("dub", "ninja")
 unittest {


### PR DESCRIPTION
First valid configuration is stored and if the default config is omitted by some reason (it is a source library for instance) then the stored configuration will be used as default one.