### PR TITLE
Don't add superfluous -fPIC for dub dynamicLibrary builds

### DIFF
--- a/payload/reggae/dub/info.d
+++ b/payload/reggae/dub/info.d
@@ -152,8 +152,6 @@ struct DubInfo {
         //package
         const projDir = isMainPackage ? "" : dubPackage.path;
 
-        const sharedFlag = targetType == TargetType.dynamicLibrary ? ["-fPIC"] : [];
-
         // -unittest should only apply to the main package
         const(string)[] deUnitTest(in string[] flags) {
             return isMainPackage
@@ -164,7 +162,6 @@ struct DubInfo {
         const flags = chain(dubPackage.dflags,
                             dubPackage.versions.map!(a => "-version=" ~ a),
                             options.dflags.splitter, // TODO: doesn't support quoted args with spaces
-                            sharedFlag,
                             deUnitTest(compilerFlags))
             .array;
 

--- a/tests/it/runtime/dub.d
+++ b/tests/it/runtime/dub.d
@@ -884,3 +884,34 @@ unittest {
     }
 
 }
+
+
+@("dynamicLibrary")
+@Tags("dub", "ninja")
+unittest {
+    with(immutable ReggaeSandbox()) {
+        writeFile(
+            "dub.sdl",
+            [
+                `name "foo"`,
+                `targetType "dynamicLibrary"`,
+            ],
+        );
+        writeFile(
+            "source/mod.d",
+            [
+                q{
+                    version (Windows) version (DigitalMars) {
+                        import core.sys.windows.dll;
+                        mixin SimpleDllMain;
+                    }
+
+                    void foo() {}
+                },
+            ],
+        );
+
+        runReggae("-b", "ninja");
+        ninja.shouldExecuteOk;
+    }
+}


### PR DESCRIPTION
As dub already adds it in that case, and LDC complains about multiple `-fPIC` occurrences (inherited from LLVM…).