### PR TITLE
Default to the ninja backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ In D, a function with return type `Build` must exist with any name.
 Normally this function isn't written by hand but by using the
 [build template mixin](payload/reggae/build.d).
 
-From the the build directory, run `reggae -b <ninja|make|tup|binary>
+From the the build directory, run `reggae [-b <ninja|make|tup|binary>]
 /path/to/your/project`. You can now build your project using the
 appropriate command (ninja, make, tup, or ./build respectively).
 
@@ -140,7 +140,7 @@ faster. An optional `ut` target corresponds to the unittest executable of
 # i.e., contains a dub.{sdl,json} file):
 mkdir build
 cd build
-reggae -b ninja ..
+reggae ..
 
 # equivalent to "dub build":
 ninja

--- a/tests/it/buildgen/backend_errors.d
+++ b/tests/it/buildgen/backend_errors.d
@@ -3,11 +3,6 @@ module tests.it.buildgen.backend_errors;
 import tests.it.buildgen;
 mixin build!(Target(`foo`));
 
-@("A backend must be specified") unittest {
-    testOptions([inOrigPath("lvl1", "lvl2")]).shouldThrowWithMessage(
-        "A backend must be specified with -b/--backend");
-}
-
 @("Backend option with non-supported backend must fail") unittest {
     testOptions(["-b", inOrigPath("lvl1", "lvl2")]).shouldThrowWithMessage(
         "Unsupported backend, -b must be one of: make|ninja|tup|binary");

--- a/tests/ut/default_options.d
+++ b/tests/ut/default_options.d
@@ -4,6 +4,13 @@ import reggae.path: buildPath;
 import unit_threaded;
 
 
+@("Default backend") unittest {
+    import reggae;
+    auto args = ["progname", "/path/to/proj"]; //fake main function args
+    auto options = getOptions(args);
+    options.backend.shouldEqual(Backend.ninja);
+}
+
 @("Default C compiler") unittest {
     import reggae;
     Options defaultOptions;


### PR DESCRIPTION
For a bit less typing for the presumably most common option, working well on Windows too.

`bootstrap.sh` still defaults to `make` (presumably more likely to come preinstalled than `ninja`, on Posix).