### PR TITLE
Add --dflag switch as alternative to --dflags

### DIFF
--- a/payload/reggae/config.d
+++ b/payload/reggae/config.d
@@ -29,6 +29,7 @@ else
 immutable Options gDefaultOptions = Options(Backend.ninja,
             "",
             "",
+            null,
             "",
             defaultCC,
             defaultCXX,

--- a/payload/reggae/config.d
+++ b/payload/reggae/config.d
@@ -28,7 +28,6 @@ else
 
 immutable Options gDefaultOptions = Options(Backend.ninja,
             "",
-            "",
             null,
             "",
             defaultCC,

--- a/payload/reggae/dub/info.d
+++ b/payload/reggae/dub/info.d
@@ -161,7 +161,7 @@ struct DubInfo {
 
         const flags = chain(dubPackage.dflags,
                             dubPackage.versions.map!(a => "-version=" ~ a),
-                            options.dflags.splitter, // TODO: doesn't support quoted args with spaces
+                            options.dflags,
                             deUnitTest(compilerFlags))
             .array;
 

--- a/payload/reggae/options.d
+++ b/payload/reggae/options.d
@@ -36,7 +36,8 @@ version(Windows) {
 struct Options {
     Backend backend;
     string projectPath;
-    string dflags;
+    private string _legacyDflags;
+    package string[] _dflags;
     string ranFromPath;
     string cCompiler;
     string cppCompiler;
@@ -64,8 +65,13 @@ struct Options {
 
     Options dup() @safe pure const nothrow {
         return Options(backend,
-                       projectPath, dflags, ranFromPath, cCompiler, cppCompiler, dCompiler,
+                       projectPath, _legacyDflags, _dflags.dup, ranFromPath, cCompiler, cppCompiler, dCompiler,
                        help, perModule, isDubProject, oldNinja, noCompilationDB, cacheBuildInfo);
+    }
+
+    const(string)[] dflags() @property @trusted pure const {
+        import std.range: split;
+        return _legacyDflags.length == 0 ? _dflags : _legacyDflags.split ~ _dflags;
     }
 
     //finished setup
@@ -231,7 +237,8 @@ Options getOptions(Options defaultOptions, string[] args) @trusted {
         auto helpInfo = getopt(
             args,
             "backend|b", "Backend to use (ninja|make|binary|tup, default is ninja).", &options.backend,
-            "dflags", "D compiler flags.", &options.dflags,
+            "dflags", "Space-separated D compiler flags (overrides previous --dflags).", &options._legacyDflags,
+            "dflag", "Extra D compiler flag to be appended.", &options._dflags,
             "d", "User-defined variables (e.g. -d myvar=foo).", &options.userVars,
             "dc", "D compiler to use (default dmd).", &options.dCompiler,
             "cc", "C compiler to use (default " ~ defaultCC ~ ").", &options.cCompiler,

--- a/src/reggae/json_build.d
+++ b/src/reggae/json_build.d
@@ -308,7 +308,7 @@ private const(Options) jsonToOptionsImpl(in Options options,
                             mixin("defaultOptions." ~ member ~ ` = false;`);
                     }
                     else static if(member == "dflags") {
-                        defaultOptions._dflags = defaultOptionsObj.object["dflags"].str.split;
+                        defaultOptions.dflags = defaultOptionsObj.object["dflags"].str.split;
                     }
                     else
                         mixin("defaultOptions." ~ member ~ ` = defaultOptionsObj.object["` ~ member ~ `"].str.to!T;`);

--- a/src/reggae/json_build.d
+++ b/src/reggae/json_build.d
@@ -307,6 +307,9 @@ private const(Options) jsonToOptionsImpl(in Options options,
                         else if(type == JSONType.false_)
                             mixin("defaultOptions." ~ member ~ ` = false;`);
                     }
+                    else static if(member == "dflags") {
+                        defaultOptions._dflags = defaultOptionsObj.object["dflags"].str.split;
+                    }
                     else
                         mixin("defaultOptions." ~ member ~ ` = defaultOptionsObj.object["` ~ member ~ `"].str.to!T;`);
                 }

--- a/tests/ut/options.d
+++ b/tests/ut/options.d
@@ -11,3 +11,15 @@ unittest {
     getOptions(["reggae", "-b", "ninja", "--per-module", "--all-at-once"]).shouldThrowWithMessage(
         "Cannot specify both --per-module and --all-at-once");
 }
+
+@("--dflags and --dflag")
+unittest {
+    getOptions(["reggae", "--dflags=-a -b"]).dflags.should == ["-a", "-b"];
+    getOptions(["reggae", "--dflags=-a", "--dflags=-b"]).dflags.should == ["-b"];
+
+    getOptions(["reggae", "--dflag=-Imy dir"]).dflags.should == ["-Imy dir"];
+    getOptions(["reggae", "--dflag=-a", "--dflag=-b"]).dflags.should == ["-a", "-b"];
+
+    getOptions(["reggae", "--dflags=-a -b", "--dflag=-c", "--dflag=-d"]).dflags.should == ["-a", "-b", "-c", "-d"];
+    getOptions(["reggae", "--dflags=-a -b", "--dflag=-c", "--dflag=-d", "--dflags=-e"]).dflags.should == ["-e", "-c", "-d"];
+}


### PR DESCRIPTION
Which comes in handy when e.g. building a reggae cmdline in a script, and extra D flags are to be appended, without overriding previously specified ones.

It also enables specifying D flags containing spaces.