### PR TITLE
Bump dub to v1.29.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,7 +13,7 @@
     "excludedSourceFiles": ["payload/reggae/buildgen_main.d", "payload/reggae/dcompile.d"],
     "mainSourceFile": "src/reggae/reggae_main.d",
     "dependencies": {
-        "dub": "~>1.28.0-rc"
+        "dub": "==1.29.0"
     },
     "subConfigurations": {
         "dub": "library"

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"dub": "1.28.0-rc.1",
-		"unit-threaded": "2.0.3"
+		"dub": "1.29.0",
+		"unit-threaded": "2.0.5"
 	}
 }


### PR DESCRIPTION
With a significant breaking change - we need to replace the special dub variables in pre/post build commands manually now (see
https://github.com/dlang/dub/pull/2217).