### PR TITLE
Support dub's actual (and special) `dub test` configuration

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -11,7 +11,7 @@ jobs:
         # Remember to change the compiler versions further below as well as here
         dc:
           - dmd-2.100.0
-          - ldc-1.29.0
+          - ldc-1.30.0
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
-        dc: [dmd-2.098.0, ldc-1.28.0]
+        dc: [dmd-2.100.0, ldc-1.30.0]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -249,8 +249,7 @@ flags, an empty parameter list must be added, e.g.:
 dubTestTarget
 -------------
 
-The target that would be built by `dub test`, with the difference that the executable
-name is always `ut`.
+The target that would be built by `dub test`.
 
 dubConfigurationTarget
 ----------------------

--- a/dub.json
+++ b/dub.json
@@ -13,7 +13,7 @@
     "excludedSourceFiles": ["payload/reggae/buildgen_main.d", "payload/reggae/dcompile.d"],
     "mainSourceFile": "src/reggae/reggae_main.d",
     "dependencies": {
-        "dub": "==1.29.0"
+        "dub": "==1.30.0"
     },
     "subConfigurations": {
         "dub": "library"

--- a/dub.json
+++ b/dub.json
@@ -27,7 +27,6 @@
           "sourcePaths": ["tests", "payload"],
           "mainSourceFile": "tests/ut_main.d",
           "versions": ["ReggaeTest"],
-          "dflags": ["-allinst"],
           "excludedSourceFiles": ["payload/reggae/buildgen_main.d",
                                   "src/reggae/reggae_main.d",
                                   "tests/projects/project1/src/main.d",

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"dub": "1.29.0",
+		"dub": {"repository":"git+https://github.com/dlang/dub.git","version":"96d125be4b9d7b56cf10465ecd98dc9b209f06d4"},
 		"unit-threaded": "2.0.5"
 	}
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"dub": {"repository":"git+https://github.com/dlang/dub.git","version":"c8f4246ea766747b8b536c51283ebb84988be092"},
+		"dub": {"repository":"git+https://github.com/dlang/dub.git","version":"ade359c4d8ea8e9cbd8fc5d11cd8ff654d3cb53c"},
 		"unit-threaded": "2.0.5"
 	}
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"dub": {"repository":"git+https://github.com/dlang/dub.git","version":"96d125be4b9d7b56cf10465ecd98dc9b209f06d4"},
+		"dub": {"repository":"git+https://github.com/dlang/dub.git","version":"c8f4246ea766747b8b536c51283ebb84988be092"},
 		"unit-threaded": "2.0.5"
 	}
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"dub": {"repository":"git+https://github.com/dlang/dub.git","version":"ade359c4d8ea8e9cbd8fc5d11cd8ff654d3cb53c"},
+		"dub": "1.30.0",
 		"unit-threaded": "2.0.5"
 	}
 }

--- a/payload/reggae/rules/dub.d
+++ b/payload/reggae/rules/dub.d
@@ -85,7 +85,7 @@ static if(isDubProject) {
 
         const config = "unittest" in configToDubInfo ? "unittest" : "default";
         auto actualCompilerFlags = compilerFlags.value;
-        if("unittest" !in configToDubInfo) actualCompilerFlags ~= "-unittest";
+        if(config != "unittest") actualCompilerFlags ~= "-unittest";
         const dubInfo = configToDubInfo[config];
         enforce(dubInfo.packages.length, text("No dub packages found for config '", config, "'"));
         const hasMain = dubInfo.packages[0].mainSourceFile != "";

--- a/payload/reggae/rules/dub.d
+++ b/payload/reggae/rules/dub.d
@@ -81,30 +81,31 @@ static if(isDubProject) {
     {
         import reggae.dub.info: TargetType, targetName;
         import std.exception : enforce;
-        import std.conv: text;
 
-        const config = "unittest" in configToDubInfo ? "unittest" : "default";
-        auto actualCompilerFlags = compilerFlags.value;
-        if(config != "unittest") actualCompilerFlags ~= "-unittest";
-        const dubInfo = configToDubInfo[config];
-        enforce(dubInfo.packages.length, text("No dub packages found for config '", config, "'"));
-        const hasMain = dubInfo.packages[0].mainSourceFile != "";
-        const string[] emptyStrings;
-        const extraLinkerFlags = hasMain ? emptyStrings : ["-main"];
-        const actualLinkerFlags = extraLinkerFlags ~ linkerFlags.value;
-        const defaultTargetHasName = configToDubInfo["default"].packages.length > 0;
-        const sameNameAsDefaultTarget =
-            defaultTargetHasName
-            && dubInfo.targetName == configToDubInfo["default"].targetName;
-        const name = sameNameAsDefaultTarget
-            // don't emit two targets with the same name
-            ? targetName(TargetType.executable, "ut")
-            : dubInfo.targetName;
+        // No `dub test` config? Then it inherited some `targetType "none"`, and
+        // dub has printed an according message - return a dummy target and continue.
+        // [Similarly, `dub test` is a no-op and returns success in such scenarios.]
+        if ("unittest" !in configToDubInfo)
+            return Target(null);
+
+        const dubInfo = configToDubInfo["unittest"];
+        enforce(dubInfo.packages.length, "No dub packages found for the dub test configuration");
+        enforce(dubInfo.packages[0].mainSourceFile.length, "No mainSourceFile for the dub test configuration");
+
+        auto name = dubInfo.targetName;
+        const defaultDubInfo = configToDubInfo["default"];
+        if (defaultDubInfo.packages.length > 0 && defaultDubInfo.targetName == name) {
+            // The targetName of both default & test configs conflict (due to a bad
+            // `unittest` config in dub.{sdl,json}).
+            // Rename the test target to `ut[.exe]` to prevent conflicts in Ninja/make
+            // build scripts (in case the default config is included in the build too).
+            name = targetName(TargetType.executable, "ut");
+        }
 
         return dubTarget(name,
                          dubInfo,
-                         actualCompilerFlags,
-                         actualLinkerFlags,
+                         compilerFlags.value,
+                         linkerFlags.value,
                          compilationMode);
     }
 

--- a/src/reggae/dub/interop/configurations.d
+++ b/src/reggae/dub/interop/configurations.d
@@ -10,4 +10,5 @@ import reggae.from;
 struct DubConfigurations {
     string[] configurations;
     string default_;
+    string test; // special `dub test` config
 }

--- a/src/reggae/dub/interop/dublib.d
+++ b/src/reggae/dub/interop/dublib.d
@@ -74,10 +74,14 @@ struct Dub {
         return ret;
     }
 
-    DubConfigurations getConfigs(/*in*/ ref from!"dub.platform".BuildPlatform platform) {
+    DubConfigurations getConfigs(/*in*/ ref from!"dub.generators.generator".GeneratorSettings settings) {
 
         import std.algorithm.iteration: filter, map;
         import std.array: array;
+
+        // add the special `dub test` configuration
+        const testConfig = _project.addTestRunnerConfiguration(settings);
+        const haveSpecialTestConfig = testConfig.length && testConfig != "unittest";
 
         // A violation of the Law of Demeter caused by a dub bug.
         // Otherwise _project.configurations would do, but it fails for one
@@ -86,12 +90,15 @@ struct Dub {
             .rootPackage
             .recipe
             .configurations
-            .filter!(c => c.matchesPlatform(platform))
+            .filter!(c => c.matchesPlatform(settings.platform))
             .map!(c => c.name)
+            // exclude unittest config if there's a derived special one
+            .filter!(n => !haveSpecialTestConfig || n != "unittest")
             .array;
 
         // Project.getDefaultConfiguration() requires a mutable arg (forgotten `in`)
-        return DubConfigurations(configurations, _project.getDefaultConfiguration(platform));
+        const defaultConfig = _project.getDefaultConfiguration(settings.platform);
+        return DubConfigurations(configurations, defaultConfig, testConfig);
     }
 
     DubInfo configToDubInfo

--- a/src/reggae/dub/interop/dublib.d
+++ b/src/reggae/dub/interop/dublib.d
@@ -75,7 +75,7 @@ struct Dub {
     }
 
     DubConfigurations getConfigs
-    (/*in*/ from!"dub.generators.generator".GeneratorSettings settings, in string singleConfig = null)
+    (in from!"dub.generators.generator".GeneratorSettings settings, in string singleConfig = null)
     {
         import std.algorithm.iteration: filter, map;
         import std.array: array;
@@ -107,7 +107,6 @@ struct Dub {
             .filter!(n => !haveSpecialTestConfig || n != "unittest")
             .array;
 
-        // Project.getDefaultConfiguration() requires a mutable arg (forgotten `in`)
         const defaultConfig = _project.getDefaultConfiguration(settings.platform);
         return DubConfigurations(configurations, defaultConfig, testConfig);
     }

--- a/src/reggae/dub/interop/dublib.d
+++ b/src/reggae/dub/interop/dublib.d
@@ -37,7 +37,7 @@ struct Dub {
     import reggae.options: Options;
     import dub.project: Project;
 
-    private Project _project;
+    package Project _project;
 
     this(in Options options) @safe {
         import reggae.path: buildPath;

--- a/src/reggae/dub/interop/dublib.d
+++ b/src/reggae/dub/interop/dublib.d
@@ -85,7 +85,7 @@ struct Dub {
         // add the special `dub test` configuration (which doesn't require an existing `unittest` config)
         const testConfig = (allConfigs || singleConfig == "unittest")
             ? _project.addTestRunnerConfiguration(settings)
-            : null;
+            : null; // skip when requesting a single non-unittest config
         const haveSpecialTestConfig = testConfig.length && testConfig != "unittest";
 
         if (!allConfigs) {

--- a/src/reggae/dub/interop/package.d
+++ b/src/reggae/dub/interop/package.d
@@ -138,6 +138,7 @@ dubConfigurations
 {
     import reggae.dub.interop.configurations: DubConfigurations;
     import reggae.io: log;
+    import std.exception: enforce;
 
     if(options.dubConfig == "") {
 
@@ -151,7 +152,14 @@ dubConfigurations
 
         return ret;
     } else {
-        return DubConfigurations([options.dubConfig], options.dubConfig);
+        string dubConfig = options.dubConfig;
+        if(dubConfig == "unittest") {
+            // mimic `dub build --config=unittest` for the special `dub test` configuration
+            // (which doesn't require an existing `unittest` configuration)
+            dubConfig = dub._project.addTestRunnerConfiguration(settings);
+            enforce(dubConfig.length, "No usable dub test configuration");
+        }
+        return DubConfigurations([dubConfig], dubConfig);
     }
 }
 

--- a/src/reggae/dub/interop/package.d
+++ b/src/reggae/dub/interop/package.d
@@ -103,7 +103,7 @@ private from!"reggae.dub.info".DubInfo getDubInfo
 
         auto settings = dub.getGeneratorSettings(options);
         const configs = dubConfigurations(output, dub, options, settings);
-        const haveTestConfig = configs.test.length != 0;
+        const haveTestConfig = configs.test != "";
         bool atLeastOneConfigOk;
         Exception dubInfoFailure;
 
@@ -127,7 +127,7 @@ private from!"reggae.dub.info".DubInfo getDubInfo
         gDubInfos["default"] = gDubInfos[configs.default_];
 
         // (additionally) expose the special `dub test` config as `unittest` config in the DSL (`configToDubInfo`)
-        // (`dubTestTarget!()`, `dubConfigurationTarget!(Configuration("unittest"))` etc.)
+        // (for `dubTestTarget!()`, `dubConfigurationTarget!(Configuration("unittest"))` etc.)
         if(haveTestConfig && configs.test != "unittest" && configs.test in gDubInfos)
             gDubInfos["unittest"] = gDubInfos[configs.test];
     }
@@ -145,7 +145,6 @@ dubConfigurations
 {
     import reggae.dub.interop.configurations: DubConfigurations;
     import reggae.io: log;
-    import std.exception: enforce;
 
     const allConfigs = options.dubConfig == "";
 

--- a/src/reggae/dub/interop/package.d
+++ b/src/reggae/dub/interop/package.d
@@ -11,7 +11,7 @@ public import reggae.dub.interop.reggaefile;
 from!"reggae.dub.info".DubInfo[string] gDubInfos;
 
 
-void writeDubConfig(T)(auto ref T output,
+void writeDubConfig(O)(ref O output,
                        in from!"reggae.options".Options options,
                        from!"std.stdio".File file) {
     import reggae.io: log;
@@ -83,8 +83,8 @@ private string ensureDubSelectionsJson
 
 
 private from!"reggae.dub.info".DubInfo getDubInfo
-    (T)
-    (auto ref T output,
+    (O)
+    (ref O output,
      ref from!"reggae.dub.interop.dublib".Dub dub,
      in from!"reggae.options".Options options)
 {
@@ -141,7 +141,7 @@ dubConfigurations
     (ref O output,
      ref from!"reggae.dub.interop.dublib".Dub dub,
      in from!"reggae.options".Options options,
-     from!"dub.generators.generator".GeneratorSettings settings)
+     in from!"dub.generators.generator".GeneratorSettings settings)
 {
     import reggae.dub.interop.configurations: DubConfigurations;
     import reggae.io: log;
@@ -210,7 +210,7 @@ private from!"reggae.dub.info".DubInfo handleDubConfig
 }
 
 
-private void callPreBuildCommands(T)(auto ref T output,
+private void callPreBuildCommands(O)(ref O output,
                                      in from!"reggae.options".Options options,
                                      in from!"reggae.dub.info".DubInfo dubInfo)
     @safe

--- a/src/reggae/dub/interop/package.d
+++ b/src/reggae/dub/interop/package.d
@@ -118,7 +118,9 @@ private from!"reggae.dub.info".DubInfo getDubInfo
         }
 
         gDubInfos["default"] = gDubInfos[configs.default_];
-        // add/replace the special `dub test` config as `unittest` config
+
+        // (additionally) expose the special `dub test` config as `unittest` config in the DSL (`configToDubInfo`)
+        // (`dubTestTarget!()`, `dubConfigurationTarget!(Configuration("unittest"))` etc.)
         if(haveTestConfig && configs.test != "unittest")
             gDubInfos["unittest"] = gDubInfos[configs.test];
 

--- a/tests/it/runtime/dub.d
+++ b/tests/it/runtime/dub.d
@@ -33,7 +33,7 @@ unittest {
 
         // there's only one UT in main.d which always fails
         ninja(["ut"]).shouldExecuteOk;
-        shouldFail("ut");
+        shouldFail("atest-test-application");
     }
 }
 
@@ -120,7 +120,7 @@ unittest {
         runReggae("-b", "ninja");
         ninja.shouldExecuteOk;
 
-        shouldFail("ut");
+        shouldFail("depends_on_cerealed-test-application");
     }
 }
 
@@ -777,7 +777,7 @@ unittest {
         });
         runReggae("-b", "ninja");
         ninja(["default", "ut"]).shouldExecuteOk;
-        shouldSucceed("ut");
+        shouldSucceed("foo-test-application");
     }
 }
 
@@ -791,14 +791,14 @@ unittest {
             targetType "executable"
         `);
         writeFile("source/app.d", q{
-            void main() {
-            }
-
+            void main() {}
+        });
+        writeFile("source/test.d", q{
             unittest { assert(1 == 2); }
         });
         runReggae("-b", "ninja");
         ninja(["default", "ut"]).shouldExecuteOk;
-        shouldFail("ut");
+        shouldFail("foo-test-application");
     }
 }
 

--- a/tests/it/runtime/issues.d
+++ b/tests/it/runtime/issues.d
@@ -124,10 +124,10 @@ unittest {
         );
 
         version(Windows) {
-            enum ut = `daspath\ut.exe`;
+            enum ut = `daspath\issue157-test-application.exe`;
             enum bin = `daspath\issue157.exe`;
         } else {
-            enum ut = "daspath/ut";
+            enum ut = "daspath/issue157-test-application";
             enum bin = "daspath/issue157";
         }
 
@@ -168,10 +168,10 @@ unittest {
 
         version(Windows) {
             shouldExist(`bin\issue157.exe`);
-            shouldExist(`bin\ut.exe`);
+            shouldExist(`bin\issue157-test-application.exe`);
         } else {
             shouldExist("bin/issue157");
-            shouldExist("bin/ut");
+            shouldExist("bin/issue157-test-application");
         }
     }
 }
@@ -261,11 +261,9 @@ unittest {
         version(Windows) {
             enum exe = "issue144.exe";
             enum lib = "issue144.lib";
-            enum ut  = "ut.exe";
         } else {
             enum exe = "issue144";
             enum lib = "issue144.a";
-            enum ut  = "ut";
         }
 
         runReggae("-b", "ninja", "--dub-config=daslib");
@@ -274,7 +272,7 @@ unittest {
         ninja([exe]).shouldFailToExecute.should ==
             ["ninja: error: unknown target '" ~ exe ~ "', did you mean '" ~ lib ~ "'?"];
         // No unittest target when --dub-config is used
-        ninja([ut]).shouldFailToExecute.should ==
-            ["ninja: error: unknown target '" ~ ut ~ "'"];
+        ninja(["ut"]).shouldFailToExecute.should ==
+            ["ninja: error: unknown target 'ut'"];
     }
 }

--- a/tests/projects/dub/dub.json
+++ b/tests/projects/dub/dub.json
@@ -1,6 +1,6 @@
 {
     "name": "atest",
     "targetType": "executable",
-    "importPaths": ["imps"],
+    "importPaths": ["source", "imps"],
     "stringImportPaths": ["stringies"],
 }

--- a/tests/projects/dub/source/main.d
+++ b/tests/projects/dub/source/main.d
@@ -5,8 +5,3 @@ void main(string[] args) {
     writeln(import(`banner.txt`));
     writeln(string1);
 }
-
-
-unittest {
-    assert(1 == 2, `oopsie`);
-}

--- a/tests/projects/dub/source/test.d
+++ b/tests/projects/dub/source/test.d
@@ -1,0 +1,3 @@
+unittest {
+    assert(1 == 2, `oopsie`);
+}

--- a/tests/utils.d
+++ b/tests/utils.d
@@ -113,14 +113,6 @@ struct FakeFile {
 }
 
 // stupid template emission
-int dummy() {
-    static import dub.dependency;
-    static import dub.dependencyresolver;
-    static import std.typecons;
-
-    alias Tup = std.typecons.Tuple!(
-        dub.dependencyresolver.DependencyResolver!(dub.dependency.Dependency, dub.dependency.Dependency).TreeNode,
-        dub.dependencyresolver.DependencyResolver!(dub.dependency.Dependency, dub.dependency.Dependency).TreeNodes);
-    Tup t0, t1;
-    return t0.opCmp(t1);
-}
+version (DigitalMars)
+pragma(mangle, "_D3std7sumtype__T7SumTypeTS3dub10dependency12VersionRangeTSQBg8internal10vibecompat4inet4path10NativePathTSQDcQDb10RepositoryZQEf11__invariantMxFNaNbNiNfZv")
+void dummySumtypeInvariant(void*) {}


### PR DESCRIPTION
`dub test` adds a special test configuration **if** there's either no `unittest` config, or its `targetType` isn't `executable`. That special config is *derived* from the `unittest` (or default) configuration, incl. generating and compiling-in an extra `dub_test_root` module with a `main()` entry point (and an `AliasSeq` of all root project modules). See https://github.com/dlang/dub/pull/2218 for details. That PR landed after the dub v1.29 branch-off, so will land in v1.30. https://github.com/dlang/dub/pull/2288 and https://github.com/dlang/dub/pull/2300 are additionally required for reggae and will land in v1.30 too.