### PR TITLE
Fix reinit issue after fetching dub packages

### DIFF
--- a/src/reggae/dub/interop/dublib.d
+++ b/src/reggae/dub/interop/dublib.d
@@ -162,10 +162,6 @@ struct Dub {
         generator.generate(settings);
         return DubInfo(generator.dubPackages, _options.dup);
     }
-
-    void reinit() @trusted {
-        _project.reinit;
-    }
 }
 
 

--- a/src/reggae/dub/interop/fetch.d
+++ b/src/reggae/dub/interop/fetch.d
@@ -6,10 +6,11 @@ import reggae.from;
 
 package void dubFetch(O)(
     auto ref O output,
-    ref from!"reggae.dub.interop.dublib".Dub dublib,
+    in from!"reggae.options".Options options,
     in string dubSelectionsJson)
     @trusted
 {
+    static import reggae.dub.interop.dublib;
     import reggae.io: log;
     import dub.dub: Dub, FetchOptions;
     import dub.dependency: Version;
@@ -23,6 +24,7 @@ package void dubFetch(O)(
 
     const json = parseJSON(readText(dubSelectionsJson));
 
+    auto dublib = reggae.dub.interop.dublib.Dub(options);
     foreach(dubPackageName, versionJson; json["versions"].object) {
 
         // skip the ones with a defined path
@@ -55,8 +57,6 @@ package void dubFetch(O)(
         }
     }
     output.log("Fetched dub packages");
-
-    dublib.reinit;
 }
 
 

--- a/src/reggae/dub/interop/package.d
+++ b/src/reggae/dub/interop/package.d
@@ -13,7 +13,6 @@ void writeDubConfig(O)(ref O output,
                        from!"std.stdio".File file) {
     import reggae.io: log;
     import reggae.dub.info: TargetType;
-    import reggae.dub.interop.dublib: Dub;
 
     output.log("Writing dub configuration");
     scope(exit) output.log("Finished writing dub configuration");
@@ -48,18 +47,16 @@ void writeDubConfig(O)(ref O output,
 auto dubInfos(O)(ref O output,
                  in from!"reggae.options".Options options) {
     import reggae.io: log;
-    import reggae.dub.info: TargetType;
     import reggae.dub.interop.fetch: dubFetch;
     import reggae.dub.interop.dublib: Dub;
 
     // must check for dub.selections.json before creating dub instance
     const dubSelectionsJson = ensureDubSelectionsJson(output, options);
 
-    auto dub = Dub(options);
-
-    dubFetch(output, dub, dubSelectionsJson);
+    dubFetch(output, options, dubSelectionsJson);
 
     output.log("    Getting dub build information");
+    auto dub = Dub(options);
     auto ret = getDubInfos(output, dub);
     output.log("    Got     dub build information");
 


### PR DESCRIPTION
By avoiding the problematic `reinit` call and instead using 2 `reggae.dub.interop.dublib.Dub` instances - one for the fetch, and another new-from-scratch one after the fetch.