### PR TITLE
Reduce reggae times by making dub dependency lazy

### DIFF
--- a/payload/reggae/dub/interop/dublib.d
+++ b/payload/reggae/dub/interop/dublib.d
@@ -82,7 +82,24 @@ package struct Dub {
         return ret;
     }
 
-    DubConfigurations getConfigs() {
+    imported!"reggae.dub.interop.configurations".DubConfigurations
+    dubConfigurations(O)(ref O output)
+    {
+        import reggae.dub.interop.configurations: DubConfigurations;
+        import reggae.io: log;
+
+        output.log("Getting dub configurations");
+        auto ret = getConfigs;
+        output.log("Number of dub configurations: ", ret.configurations.length);
+
+        // this happens e.g. the targetType is "none"
+        if(ret.configurations.length == 0)
+            return DubConfigurations([""], "", null);
+
+        return ret;
+    }
+
+    private DubConfigurations getConfigs() {
         import std.algorithm: filter, map, canFind;
         import std.array: array;
         import std.conv: text;

--- a/payload/reggae/dub/interop/dublib.d
+++ b/payload/reggae/dub/interop/dublib.d
@@ -63,6 +63,52 @@ package struct Dub {
         return _options;
     }
 
+    imported!"reggae.dub.info".DubInfo[string] getDubInfos(O)(ref O output)
+    {
+        import reggae.io: log;
+        import reggae.path: buildPath;
+        import reggae.dub.info: DubInfo;
+        import std.file: exists;
+        import std.exception: enforce;
+
+        DubInfo[string] ret;
+
+        enforce(buildPath(options.projectPath, "dub.selections.json").exists,
+                "Cannot find dub.selections.json");
+
+        const configs = dubConfigurations(output);
+        const haveTestConfig = configs.test != "";
+        bool atLeastOneConfigOk;
+        Exception dubInfoFailure;
+
+        foreach(config; configs.configurations) {
+            const isTestConfig = haveTestConfig && config == configs.test;
+            try {
+                ret[config] = configToDubInfo(output, config, isTestConfig);
+                atLeastOneConfigOk = true;
+            } catch(Exception ex) {
+                output.log("ERROR: Could not get info for configuration ", config, ": ", ex.msg);
+                if(dubInfoFailure is null) dubInfoFailure = ex;
+            }
+        }
+
+        if(!atLeastOneConfigOk) {
+            assert(dubInfoFailure !is null,
+                   "Internal error: no configurations worked and no exception to throw");
+            throw dubInfoFailure;
+        }
+
+        ret["default"] = ret[configs.default_];
+
+        // (additionally) expose the special `dub test` config as
+        // `unittest` config in the DSL (`configToDubInfo`) (for
+        // `dubTest!()`, `dubBuild!(Configuration("unittest"))` etc.)
+        if(haveTestConfig && configs.test != "unittest" && configs.test in ret)
+            ret["unittest"] = ret[configs.test];
+
+        return ret;
+    }
+
     private static auto getGeneratorSettings(in Options options) {
         import dub.compilers.compiler: getCompiler;
         import dub.generators.generator: GeneratorSettings;
@@ -164,7 +210,7 @@ package struct Dub {
         return DubConfigurations(configurations, defaultConfig, testConfig);
     }
 
-    imported!"reggae.dub.info".DubInfo configToDubInfo
+    private imported!"reggae.dub.info".DubInfo configToDubInfo
         (O)
         (ref O output,
          in string config,

--- a/payload/reggae/dub/interop/package.d
+++ b/payload/reggae/dub/interop/package.d
@@ -81,7 +81,7 @@ private imported!"reggae.dub.info".DubInfo[string] getDubInfos
     enforce(buildPath(dub.options.projectPath, "dub.selections.json").exists,
             "Cannot find dub.selections.json");
 
-    const configs = dubConfigurations(output, dub);
+    const configs = dub.dubConfigurations(output);
     const haveTestConfig = configs.test != "";
     bool atLeastOneConfigOk;
     Exception dubInfoFailure;
@@ -110,27 +110,6 @@ private imported!"reggae.dub.info".DubInfo[string] getDubInfos
     // `dubTest!()`, `dubBuild!(Configuration("unittest"))` etc.)
     if(haveTestConfig && configs.test != "unittest" && configs.test in ret)
         ret["unittest"] = ret[configs.test];
-
-    return ret;
-}
-
-
-private imported!"reggae.dub.interop.configurations".DubConfigurations
-dubConfigurations
-    (O)
-    (ref O output,
-     ref imported!"reggae.dub.interop.dublib".Dub dub)
-{
-    import reggae.dub.interop.configurations: DubConfigurations;
-    import reggae.io: log;
-
-    output.log("Getting dub configurations");
-    auto ret = dub.getConfigs;
-    output.log("Number of dub configurations: ", ret.configurations.length);
-
-    // this happens e.g. the targetType is "none"
-    if(ret.configurations.length == 0)
-        return DubConfigurations([""], "", null);
 
     return ret;
 }

--- a/payload/reggae/dub/interop/package.d
+++ b/payload/reggae/dub/interop/package.d
@@ -2,7 +2,7 @@
    A module for providing interop between reggae and dub
 */
 module reggae.dub.interop;
-version(Have_dub):
+
 
 string dubConfigSource(O)(ref O output, in imported!"reggae.options".Options options) {
     import reggae.dub.info: TargetType;
@@ -48,19 +48,22 @@ imported!"reggae.dub.info".DubInfo[string] dubInfos(O)
     (ref O output,
      in imported!"reggae.options".Options options)
 {
-    import reggae.io: log;
-    import reggae.dub.interop.dublib: Dub, fetchDubDeps;
-    import std.file: readText;
+    version(Have_dub) {
+        import reggae.io: log;
+        import reggae.dub.interop.dublib: Dub, fetchDubDeps;
+        import std.file: readText;
 
-    output.log("Fetching dub dependencies");
-    fetchDubDeps(options.projectPath);
-    output.log("Dub dependencies fetched");
+        output.log("Fetching dub dependencies");
+        fetchDubDeps(options.projectPath);
+        output.log("Dub dependencies fetched");
 
-    output.log("Creating dub instance");
-    auto dub = Dub(options);
-    output.log("Getting dub information");
-    auto ret = dub.getDubInfos(output);
-    output.log("Got dub build information");
+        output.log("Creating dub instance");
+        auto dub = Dub(options);
+        output.log("Getting dub information");
+        auto ret = dub.getDubInfos(output);
+        output.log("Got dub build information");
 
-    return ret;
+        return ret;
+    } else
+          throw new Exception("Dub not available, can't get dub information");
 }

--- a/payload/reggae/rules/dub/external.d
+++ b/payload/reggae/rules/dub/external.d
@@ -3,8 +3,6 @@
  */
 module reggae.rules.dub.external;
 
-version(Have_dub):
-
 /**
    A dub path-based dependency. The value should be a path to a dub
    package on the filesystem.

--- a/src/reggae/reggae.d
+++ b/src/reggae/reggae.d
@@ -308,6 +308,7 @@ private Binary buildReggaefileDub(O)(auto ref O output, in Options options) {
     // below.
     const dubRecipeDir = hiddenDirAbsPath(options);
     const dubRecipePath = buildPath(dubRecipeDir, "dub.sdl");
+
     writeIfDiffers(
         output,
         dubRecipePath,
@@ -334,16 +335,13 @@ private Binary buildReggaefileDub(O)(auto ref O output, in Options options) {
     // `options.reggaeFileDepFile` existing, which means we need to
     // compile the reggaefile separately to get those dependencies
     // *then* add any extra files to the dummy dub.sdl.
-    const dubVersions = ["Have_dub", "DubUseCurl"];
-    const versionFlag = options.isLdc ? "-d-version" : "-version";
-    const dubVersionFlags = dubVersions.map!(a => versionFlag ~ "=" ~ a).array;
     auto reggaefileObj = Binary(
-        "reggaefile" ~ objExt,
+        "reggaefile" ~ objExt, // dummy name that doesn't matter
         [
             options.dCompiler,
             options.reggaeFilePath, "-o-", "-makedeps=" ~ options.reggaeFileDepFile,
          ]
-        ~ dubVersionFlags ~ importPaths(options) ~ dubImportFlags(options),
+        ~ importPaths(options),
     );
     buildBinary(output, options, reggaefileObj);
 


### PR DESCRIPTION
It was taking forever to calculate dependencies for the reggaefile due to `-version=Have_dub`.