### PR TITLE
Windows: Fix superfluous reggae re-runs due to newline diff

### DIFF
--- a/src/reggae/reggae.d
+++ b/src/reggae/reggae.d
@@ -392,7 +392,7 @@ private void writeIfDiffers(O)(auto ref O output, in string path, in string cont
     import std.array: replace;
     import std.path: dirName;
 
-    if(!path.exists || path.readText.replace("\r\n", "\n") != contents) {
+    if(!path.exists || path.readText.replace("\r\n", "\n") != contents.replace("\r\n", "\n")) {
         output.log("Writing ", path);
         if(!path.dirName.exists)
             mkdirRecurse(path.dirName);


### PR DESCRIPTION
The problem with multi-line string literals (used here as file contents, e.g., for `buildgen_main.d`) is that they inherit the newline of the source file. And on Windows, this is governed by git's `autocrlf` setting; `\n` being converted to `\r\n` is the default setting AFAIK.