### PR TITLE
Always use dub to build the reggaefile

### DIFF
--- a/payload/reggae/rules/common.d
+++ b/payload/reggae/rules/common.d
@@ -654,6 +654,6 @@ Language getLanguage(in string srcFileName) @safe pure nothrow {
     }
 }
 
-private Target[] emptyTargets() @safe @nogc pure nothrow {
+package Target[] emptyTargets() @safe @nogc pure nothrow {
     return null;
 }

--- a/payload/reggae/rules/d.d
+++ b/payload/reggae/rules/d.d
@@ -316,7 +316,7 @@ Target scriptlike(App app,
                   Flags flags = Flags(),
                   ImportPaths importPaths = ImportPaths(),
                   StringImportPaths stringImportPaths = StringImportPaths(),
-                  alias linkWithFunction = () { return cast(Target[])[];})
+                  alias linkWithFunction = imported!"reggae.rules.common".emptyTargets)
     () @trusted
 {
     auto linkWith = linkWithFunction();


### PR DESCRIPTION
This means taking advantage of not always having to calculate the dependency file, and hardly every having to rebuild the reggae code itself due to dub picking up when it needs to build.