### PR TITLE
Only perform 'dub upgrade' if there are missing dub dependencies

### DIFF
--- a/payload/reggae/dub/interop/dublib.d
+++ b/payload/reggae/dub/interop/dublib.d
@@ -47,9 +47,6 @@ package struct Dub {
 
         _options = options;
 
-        const path = buildPath(options.projectPath, "dub.selections.json");
-        enforce(path.exists, "Cannot create dub instance without dub.selections.json");
-
         import dub.dub: DubClass = Dub;
         import dub.internal.vibecompat.inet.path: NativePath;
 
@@ -72,9 +69,6 @@ package struct Dub {
         import std.exception: enforce;
 
         DubInfo[string] ret;
-
-        enforce(buildPath(options.projectPath, "dub.selections.json").exists,
-                "Cannot find dub.selections.json");
 
         const configs = dubConfigurations(output);
         const haveTestConfig = configs.test != "";
@@ -267,7 +261,8 @@ public void fetchDubDeps(in string projectPath) @trusted {
 
     scope dub = new Dub(projectPath);
     dub.loadPackage();
-    dub.upgrade(UpgradeOptions.select);
+    if (!dub.project.hasAllDependencies)
+        dub.upgrade(UpgradeOptions.select);
 }
 
 

--- a/tests/it/runtime/dub/proper.d
+++ b/tests/it/runtime/dub/proper.d
@@ -130,7 +130,7 @@ unittest {
 
     import std.process: execute;
 
-    with(immutable ReggaeSandbox("dub")) {
+    with(immutable ReggaeSandbox("dub_prebuild")) {
         runReggae("-b", "make");
         make(["VERBOSE=1"]).shouldExecuteOk.shouldContain("-debug -g");
         {


### PR DESCRIPTION
Just like dub does it: https://github.com/dlang/dub/blob/374842d3bf87ce2c00a4f373b8a84b96e2279d33/source/dub/commandline.d#L1341-L1347

This helps especially with a partial `dub.selections.json`, not containing selections for path-based deps (in the .sdl/json), where dub is pretty dumb and can easily take 5 seconds to 'upgrade' those (unless using `--skip-registry=all`, which we cannot do in general).