### PR TITLE
Only create GeneratorSettings once

### DIFF
--- a/payload/reggae/io.d
+++ b/payload/reggae/io.d
@@ -20,7 +20,8 @@ void log(O, T...)(auto ref O output, auto ref T args) {
 private string secondsSinceStartString() @safe {
     import std.string: rightJustify;
     import std.conv: to;
-    return ("+" ~ (sinceStart / 1000.0).to!string).rightJustify(8, ' ');
+    import std.format: format;
+    return ("+" ~ (sinceStart / 1000.0).format!"%03.3f"()).rightJustify(8, ' ');
 }
 
 


### PR DESCRIPTION
For "reasons" it takes ~11ms on my laptop. Before this PR it was called once to get the list of configurations, then again for each one of them.