### PR TITLE
Restore relative output paths for DubPathDependency targets

### DIFF
--- a/payload/reggae/rules/dub/external.d
+++ b/payload/reggae/rules/dub/external.d
@@ -142,9 +142,8 @@ private struct DubPathDependency {
         // whole path to a target.
 
         return dubBuild(subOptions, dubInfo)
-            .mapOutputs((string o) => buildNormalizedPath(projectPath,
-                                                          subOptions.projectPath.relativePath(projectPath),
-                                                          o));
+            .mapOutputs((string o) => buildNormalizedPath(
+                subOptions.projectPath.relativePath(projectPath), o));
     }
 }
 

--- a/src/reggae/reggae.d
+++ b/src/reggae/reggae.d
@@ -445,6 +445,8 @@ private string buildReggaefileWithReggae(
     import std.stdio: stdout;
     buildReggaefileDub(stdout, options, Yes.needDub);
 
+    const dubRecipeDir = hiddenDirAbsPath(options);
+
     // FIXME - use correct D compiler.
     // The reason it doesn't work now is due to a test using
     // a custom compiler
@@ -453,8 +455,9 @@ private string buildReggaefileWithReggae(
     auto newOptions = options.dup;
     newOptions.backend = Backend.binary;
     newOptions.dubObjsDir = dubObjsDir;
+    newOptions.projectPath = dubRecipeDir;
+    newOptions.workingDir = dubRecipeDir;
 
-    const dubRecipeDir = hiddenDirAbsPath(options);
     auto build = Build(dubPackage(newOptions, DubPath(dubRecipeDir)));
 
     runtimeBuild(newOptions, build);

--- a/tests/it/runtime/dub/dependencies.d
+++ b/tests/it/runtime/dub/dependencies.d
@@ -522,9 +522,14 @@ unittest {
             }
         );
 
+        enum relativeOutputPath = "over/there/bin/ut" ~ exeExt;
+
         runReggae("-b", "ninja");
         ninja.shouldExecuteOk;
-        shouldSucceed("over/there/bin/ut" ~ exeExt);
+        shouldSucceed(relativeOutputPath);
+
+        // make sure the ninja target is relative, not absolute
+        ninja([relativeOutputPath]).shouldExecuteOk;
     }
 }
 


### PR DESCRIPTION
This was recently changed to absolute paths in f1c098d3e53f87f15e98adfabd97b89a5d3b45a3.