### PR TITLE
Windows: Resolve path to lib.exe (for static libs) at reggae-time

### DIFF
--- a/payload/reggae/rules/common.d
+++ b/payload/reggae/rules/common.d
@@ -487,7 +487,7 @@ Target staticLibrary(
     );
 }
 
-Target staticLibraryTarget(in string name, Target[] objects) @safe pure {
+Target staticLibraryTarget(in string name, Target[] objects) @safe {
     import std.path: defaultExtension;
     return Target(
         [buildPath("$builddir", defaultExtension(name, libExt))],
@@ -496,7 +496,7 @@ Target staticLibraryTarget(in string name, Target[] objects) @safe pure {
     );
 }
 
-Target staticLibraryTarget(in string name, Target[] objects, Target[] implicits) @safe pure {
+Target staticLibraryTarget(in string name, Target[] objects, Target[] implicits) @safe {
     import std.path: defaultExtension;
     return Target(
         [buildPath("$builddir", defaultExtension(name, libExt))],
@@ -506,10 +506,19 @@ Target staticLibraryTarget(in string name, Target[] objects, Target[] implicits)
     );
 }
 
-version(Windows)
-    private enum staticLibraryShellCommand = "lib.exe /OUT:$out $in";
-else
-    private enum staticLibraryShellCommand = "ar rcs $out $in";
+private string staticLibraryShellCommand() @safe {
+    version(Windows) {
+        import reggae.options: resolveExecutable;
+
+        static string libExe;
+        if (!libExe.length)
+            libExe = resolveExecutable("lib.exe");
+
+        return `"` ~ libExe ~ `" /OUT:$out $in`;
+    } else {
+        return "ar rcs $out $in";
+    }
+}
 
 private Target[] srcFilesToObjectTargets(
     in imported!"reggae.options".Options options,

--- a/tests/it/rules/static_lib.d
+++ b/tests/it/rules/static_lib.d
@@ -1,0 +1,26 @@
+module tests.it.rules.static_lib;
+
+import tests.it.runtime;
+
+@("C archiver command in ninja rule")
+@Tags("ninja")
+unittest {
+    with(immutable ReggaeSandbox()) {
+        writeFile(
+            "reggaefile.d",
+            q{
+                import reggae;
+                alias lib = staticLibrary!("mylib", Sources!("src"));
+                mixin build!lib;
+            }
+        );
+
+        writeFile("src/foo.c", "void foo() {}");
+        runReggae("-b", "ninja");
+
+        version(Windows) // should have resolved path to lib.exe
+            fileShouldContain("build.ninja", `\lib.exe" /OUT:`);
+        else
+            fileShouldContain("build.ninja", "before = ar rcs ");
+    }
+}

--- a/tests/main.d
+++ b/tests/main.d
@@ -48,6 +48,7 @@ int main(string[] args) {
         "tests.it.rules.json_build",
         "tests.it.rules.cmake",
         "tests.it.rules.d_cmake_interop",
+        "tests.it.rules.static_lib",
         "tests.it.runtime.lua",
         "tests.it.runtime.javascript",
         "tests.it.runtime.user_vars",


### PR DESCRIPTION
Otherwise, a set-up MSVC environment is required for the build too, not just the reggae invocation. cl.exe is already resolved to an absolute path.