### PR TITLE
Avoid threading issues to begin with

### DIFF
--- a/payload/reggae/options.d
+++ b/payload/reggae/options.d
@@ -61,11 +61,12 @@ struct Options {
     string dubConfig;
     string[] reggaefileImportPaths;
     bool buildReggaefileWithDub;
-    // Use absolute paths in the `targetPath` function.
-    // This is needed because for users we want the output paths to be relative so they
-    // don't have to type in an absolute path to build their binary, but for internal
-    // reggae use, we do.
+    // Use absolute paths in the `targetPath` function.  This is
+    // needed because for users we want the output paths to be
+    // relative so they don't have to type in an absolute path to
+    // build their binary, but for internal reggae use, we do.
     bool dubTargetPathAbs;
+    bool buildReggaefileSingle; // single-threaded build using the binary backend
     string[string] userVars; // must be last
 
     Options dup() @safe pure const nothrow scope {
@@ -323,6 +324,7 @@ Options getOptions(Options defaultOptions, string[] args) @trusted {
             "dub-config", "Only use this dub configuration", &options.dubConfig,
             "reggaefile-import-path", "Import paths for the reggaefile itself", &options.reggaefileImportPaths,
             "build-reggaefile-with-dub", "Build the reggaefile with dub instead of the binary backend", &options.buildReggaefileWithDub,
+            "build-reggaefile-single", "Build the reggaefile using a single thread", &options.buildReggaefileSingle,
         );
 
         if(helpInfo.helpWanted) {

--- a/tests/it/runtime/package.d
+++ b/tests/it/runtime/package.d
@@ -111,7 +111,12 @@ private:
             static assert(false, "Unknown D compiler");
 
         const dubObjsDir = buildPath(buildgenDubObjsDir, "test");
-        return testRun(["reggae", "--dub-objs-dir=" ~ dubObjsDir] ~ fromWhereArgs ~ args ~ project);
+        // tell the binary backend to use a single thread since we'll
+        // be using many of them to run the tests themselves.
+        return testRun(
+            ["reggae", "--dub-objs-dir=" ~ dubObjsDir, "--build-reggaefile-single"] ~
+            fromWhereArgs ~ args ~ project
+        );
     }
 }
 


### PR DESCRIPTION
The binary backend by default spawns threads for every build, and now we're using it to both calculate the reggafile dependencies (in which threads won't even help), and do compile the build generator from the reggaefile. Since the tests run in threads, it won't be faster and might create the issues that this branch was created to fix. In order to still have a safety net, the horrible Windows version that tries again remains.