### PR TITLE
Stop rerunning reggae on source edits

### DIFF
--- a/payload/reggae/backend/make.d
+++ b/payload/reggae/backend/make.d
@@ -75,6 +75,7 @@ struct Makefile {
     //includes rerunning reggae
     string output() @safe {
 
+        import reggae.backend: rerunCommand;
         import std.array: join;
         import std.range: chain;
         import std.algorithm: sort, uniq;
@@ -85,10 +86,14 @@ struct Makefile {
             ret = options.eraseProjectPath(ret);
         } else {
             // add a dependency on the Makefile to reggae itself and the build description,
-            // but only if not exporting a build
+            // but only if not exporting a build. The dependencies (which
+            // include the source directories) only determine when the rerun
+            // check is invoked; the check itself decides whether reggae
+            // actually needs to be rerun, so that editing an existing
+            // source file doesn't regenerate the build.
             auto srcDirs = _srcDirs.sort.uniq;
             const flattenedInputs = chain(options.reggaeFileDependencies, srcDirs).join(" ");
-            const rerunLine = "\t" ~ options.rerunArgs.join(" ") ~ "\n";
+            const rerunLine = "\t" ~ rerunCommand(options) ~ "\n";
 
             ret ~= fileName() ~ ": " ~ flattenedInputs ~ "\n";
             ret ~= rerunLine;
@@ -102,12 +107,15 @@ struct Makefile {
     }
 
     void writeBuild() @safe {
+        import reggae.backend: writeRerunState;
         import std.stdio: File;
         import reggae.path: buildPath;
 
         auto output = output();
         auto file = File(buildPath(options.workingDir, fileName), "w");
         file.write(output);
+
+        writeRerunState(options, _srcDirs);
     }
 
     //the only reason this is needed is to add auto dependency

--- a/payload/reggae/backend/ninja.d
+++ b/payload/reggae/backend/ninja.d
@@ -74,12 +74,18 @@ struct Ninja {
 
     //includes rerunning reggae
     const(NinjaEntry)[] allRuleEntries() @safe pure const {
-        import std.array: join;
+        import reggae.backend: rerunCommand;
 
+        // The rerun command checks whether reggae actually needs to be
+        // rerun and does nothing otherwise, leaving build.ninja
+        // untouched. `restat = 1` then stops ninja from running the
+        // check again on the next build (the source directories'
+        // timestamps would otherwise keep triggering it).
         return ruleEntries ~ defaultRules(_options) ~
             NinjaEntry("rule _rerun",
-                       ["command = " ~ _options.rerunArgs.join(" "),
+                       ["command = " ~ rerunCommand(_options),
                         "generator = 1",
+                        "restat = 1",
                            ]);
     }
 
@@ -94,6 +100,7 @@ struct Ninja {
     }
 
     void writeBuild() @safe {
+        import reggae.backend: writeRerunState;
         import std.stdio: File;
         import reggae.path: buildPath;
 
@@ -102,6 +109,8 @@ struct Ninja {
 
         auto rulesNinja = File(buildPath(_options.workingDir, "rules.ninja"), "w");
         rulesNinja.writeln(rulesOutput);
+
+        writeRerunState(_options, _srcDirs);
     }
 
 private:
@@ -114,17 +123,10 @@ private:
     string[] _srcDirs;
 
     void defaultRule(Target target) @safe {
-        import reggae.backend: maybeAddDirDependencies;
+        import reggae.backend: flattenShellArgs, maybeAddDirDependencies;
         import std.algorithm: canFind, map, startsWith;
         import std.array: join, replace;
         import std.path: extension;
-
-        static string flattenShellArgs(in string[] args) {
-            static string quoteArgIfNeeded(string a) {
-                return !a.canFind(' ') ? a : `"` ~ a.replace(`"`, `\"`) ~ `"`;
-            }
-            return args.map!quoteArgIfNeeded.join(" ");
-        }
 
         string[] paramLines;
         foreach(immutable param; target.commandParamNames) {

--- a/payload/reggae/backend/package.d
+++ b/payload/reggae/backend/package.d
@@ -50,3 +50,168 @@ private auto trustedArray(R)(auto ref scope R rng) @trusted {
     import std.array: array;
     return rng.array;
 }
+
+private alias Options = imported!"reggae.options".Options;
+
+// What the generated build files run when any of the build
+// description's dependencies (including the source directories) is out
+// of date. `--rerun-check` only actually reruns reggae if the build
+// description could have changed - see `rerunIsNeeded`.
+package string rerunCommand(in Options options) @safe pure {
+    string[] args = [options.ranFromPath, "--rerun-check"];
+    if(options.rerunArgs.length > 1)
+        args ~= options.rerunArgs[1 .. $];
+    return flattenShellArgs(args);
+}
+
+/**
+   Whether reggae needs to be rerun to regenerate the build files.
+
+   Editing an existing source file bumps its directory's timestamp
+   (editors that save via a temporary file rename do this), which makes
+   make/ninja invoke the rerun command, but the build description only
+   changes if files were added or removed. So compare the current set
+   of files in the source directories against the set recorded when the
+   build was generated, and check if the build description itself (the
+   reggaefile and its dependencies) is newer than the generated build.
+ */
+bool rerunIsNeeded(in Options options) @safe {
+    import std.file: exists, timeLastModified;
+
+    const buildFile = buildFilePath(options);
+    if(buildFile is null || !buildFile.exists)
+        return true;
+
+    const buildFileTime = buildFile.timeLastModified;
+    foreach(dep; options.reggaeFileDependencies)
+        if(!dep.exists || dep.timeLastModified > buildFileTime)
+            return true;
+
+    const state = readRerunState(options);
+    return scanSrcFiles(options.workingDir, state.srcDirs) != state.srcFiles;
+}
+
+// Called when `rerunIsNeeded` returns false. Make would otherwise run
+// the rerun check on every invocation since the source directories
+// stay newer than the Makefile, so bump the latter's timestamp. Ninja
+// needs no equivalent (and the file must not be touched so that
+// `restat = 1` does its job).
+void skipRerun(in Options options) @safe {
+    import reggae.types: Backend;
+    import std.datetime.systime: Clock;
+    import std.file: setTimes;
+
+    if(options.backend == Backend.make) {
+        const now = Clock.currTime;
+        setTimes(buildFilePath(options), now, now);
+    }
+}
+
+private string buildFilePath(in Options options) @safe pure {
+    import reggae.path: buildPath;
+    import reggae.types: Backend;
+
+    final switch(options.backend) with(Backend) {
+        case make:
+            return buildPath(options.workingDir, "Makefile");
+        case ninja:
+            return buildPath(options.workingDir, "build.ninja");
+        case none:
+        case tup:
+        case binary:
+            return null;
+    }
+}
+
+private struct RerunState {
+    string[] srcDirs;
+    string[] srcFiles;
+}
+
+private string rerunStatePath(in Options options) @safe pure {
+    import reggae.options: hiddenDir;
+    import reggae.path: buildPath;
+    return buildPath(options.workingDir, hiddenDir, "rerun-state.json");
+}
+
+// throws if the state file doesn't exist or can't be parsed, which
+// callers treat as "rerun needed"
+private RerunState readRerunState(in Options options) @safe {
+    import std.algorithm: map;
+    import std.array: array;
+    import std.file: readText;
+    import std.json: parseJSON;
+
+    auto json = parseJSON(readText(rerunStatePath(options)));
+    RerunState ret;
+    ret.srcDirs = json.objectNoRef["srcDirs"].arrayNoRef.map!(a => a.str).array;
+    ret.srcFiles = json.objectNoRef["srcFiles"].arrayNoRef.map!(a => a.str).array;
+    return ret;
+}
+
+package void writeRerunState(in Options options, in string[] srcDirs) @safe {
+    import std.algorithm: sort, uniq;
+    import std.array: array;
+    import std.file: mkdirRecurse;
+    import std.json: JSONValue;
+    import std.path: dirName;
+    import std.stdio: File;
+
+    // exported builds don't rerun reggae
+    if(options.export_)
+        return;
+
+    const statePath = rerunStatePath(options);
+    mkdirRecurse(statePath.dirName);
+
+    auto sortedSrcDirs = srcDirs.dup.sort.uniq.array;
+    auto json = JSONValue([
+        "srcDirs": JSONValue(sortedSrcDirs),
+        "srcFiles": JSONValue(scanSrcFiles(options.workingDir, sortedSrcDirs)),
+    ]);
+
+    auto file = File(statePath, "w");
+    file.write(json.toString);
+}
+
+// All directory entries in the source directories, including ones a
+// build description might not care about (e.g. editor backup files):
+// whether a given file matters can only be known by actually running
+// the build description, so over-approximate and rerun in that case.
+// Relative source directories mean what they mean in the generated
+// build files, i.e. relative to where make/ninja run, so resolve them
+// against the working directory instead of the current one.
+private string[] scanSrcFiles(in string workingDir, in string[] srcDirs) @safe {
+    import reggae.path: buildPath;
+    import std.algorithm: sort, uniq;
+    import std.array: array;
+    import std.file: exists, isDir;
+    import std.path: isAbsolute;
+
+    string[] ret;
+    foreach(dir; srcDirs) {
+        const absDir = dir.isAbsolute ? dir : buildPath(workingDir, dir);
+        if(absDir.exists && absDir.isDir)
+            ret ~= dirEntryNames(absDir);
+    }
+
+    return ret.sort.uniq.array;
+}
+
+private string[] dirEntryNames(in string dir) @trusted {
+    import std.algorithm: map;
+    import std.array: array;
+    import std.file: dirEntries, SpanMode;
+    return dirEntries(dir, SpanMode.shallow).map!(e => e.name).array;
+}
+
+package string flattenShellArgs(in string[] args) @safe pure {
+    import std.algorithm: canFind, map;
+    import std.array: join, replace;
+
+    static string quoteArgIfNeeded(string a) {
+        return !a.canFind(' ') ? a : `"` ~ a.replace(`"`, `\"`) ~ `"`;
+    }
+
+    return args.map!quoteArgIfNeeded.join(" ");
+}

--- a/src/reggae/reggae.d
+++ b/src/reggae/reggae.d
@@ -50,8 +50,44 @@ mixin template ReggaeMain() {
 }
 
 void run(T)(auto ref T output, string[] args) {
+    import std.algorithm: canFind, filter;
+    import std.array: array;
+
+    // the generated build files call back into reggae with this flag
+    // when any of the build's dependencies is out of date
+    if(args.canFind("--rerun-check")) {
+        runRerunCheck(output, args.filter!(a => a != "--rerun-check").array);
+        return;
+    }
+
     auto options = getOptions(args);
     run(output, options);
+}
+
+// Rerun reggae if the build files need regenerating, do nothing
+// otherwise. Editing a source file bumps its directory's timestamp,
+// which triggers the build files' rerun dependency, but only
+// adding/removing files (or changing the build description itself)
+// requires regenerating the build.
+private void runRerunCheck(T)(auto ref T output, string[] args) {
+    import reggae.backend: rerunIsNeeded, skipRerun;
+    import reggae.io: log;
+
+    auto options = getOptions(args);
+
+    bool rerun = true;
+    // any failure to determine staleness means erring on the side of
+    // regenerating the build
+    try
+        rerun = rerunIsNeeded(options);
+    catch(Exception _) {}
+
+    if(rerun) {
+        run(output, options);
+    } else {
+        output.log("Build description unchanged, not rerunning reggae");
+        skipRerun(options);
+    }
 }
 
 void run(T)(auto ref T output, Options options) {

--- a/tests/it/package.d
+++ b/tests/it/package.d
@@ -12,6 +12,16 @@ shared static this() nothrow {
     import std.algorithm: map, find;
 
     try {
+        // When the build files generated in test sandboxes call back into
+        // this binary for the reggae rerun check, the current directory is
+        // the sandbox: the reggae top dir can't be found, nor is it needed.
+        {
+            import core.runtime: Runtime;
+            import std.algorithm: canFind;
+            if(Runtime.args.canFind("--rerun-check"))
+                return;
+        }
+
         auto paths = [".", ".."].map!(a => buildNormalizedPath(getcwd, a))
             .find!(a => buildNormalizedPath(a, "dub.json").exists);
         assert(!paths.empty, "Error: Cannot find reggae top dir using dub.json");

--- a/tests/it/runtime/dependencies.d
+++ b/tests/it/runtime/dependencies.d
@@ -31,14 +31,12 @@ version(DigitalMars) {
 
                 runReggae("-b", backend, "--verbose");
                 mixin(backend).shouldExecuteOk;
+                shouldSucceed("foo");
 
-                // Rerunning reggae fails in this fake environment because there is no
-                // reggae binary to rerun. So this is a hack because it tracks whether or
-                // not we rerun reggae by having the call to reggae fail at runtime.
-                // We trigger this by writing to constants.d which should have correctly
-                // been identified as an implicit dependency of the reggaefile.
-                // If things actually worked, we'd assert that there's now a file named
-                // `bar`.
+                // Writing to constants.d, which should have correctly been
+                // identified as an implicit dependency of the reggaefile,
+                // reruns reggae and the build now produces `bar` instead
+                // of `foo`.
                 writeFile(
                     "other/constants.d",
                     q{
@@ -46,14 +44,14 @@ version(DigitalMars) {
                         enum exeName = "bar"; void lefoo() { }
                     }
                 );
-                mixin(backend).shouldFailToExecute.shouldContain("reggae");
-
-                runReggae("-b", backend); // but this should be fine
-                mixin(backend).shouldExecuteOk; // it's rerun, so make/ninja succeeds
+                mixin(backend).shouldExecuteOk;
+                shouldSucceed("bar");
 
                 // test that adding a file triggers a rerun
                 writeFile("source/foo.d");
-                mixin(backend).shouldFailToExecute.shouldContain("reggae");
+                mixin(backend)
+                    .shouldExecuteOk
+                    .shouldNotContain("Build description unchanged");
             }
         }
  }

--- a/tests/it/runtime/issues.d
+++ b/tests/it/runtime/issues.d
@@ -482,6 +482,53 @@ unittest {
 
 version(DigitalMars) {
     static foreach(backend; ["ninja", "make"]) {
+        @("rerun.changed.file." ~ backend)
+        @Tags(backend)
+        unittest {
+            import std.file: rename, timeLastModified;
+
+            with(immutable ReggaeSandbox()) {
+                writeFile(
+                    "reggaefile.d",
+                    q{
+                        import reggae;
+                        alias lib = staticLibrary!(
+                            "mylib",
+                            Sources!("source")
+                        );
+                        mixin build!lib;
+                    }
+                );
+                writeFile("source/app.d", "void main() {}");
+
+                runReggae("-b", backend, "--verbose");
+                mixin(backend).shouldExecuteOk;
+
+                static if(backend == "ninja")
+                    const before = timeLastModified(inSandboxPath("build.ninja"));
+
+                // Simulate an editor save by renaming a temp file over the
+                // source. Editors such as Emacs do this, and it bumps the
+                // parent directory's mtime without changing the source set.
+                writeFile("source/app.d.tmp", "void main() {}");
+                rename(
+                    inSandboxPath("source/app.d.tmp"),
+                    inSandboxPath("source/app.d"),
+                );
+
+                mixin(backend)
+                    .shouldExecuteOk
+                    .shouldContain("Build description unchanged");
+
+                // make has no equivalent of ninja's restat, so the
+                // Makefile's timestamp gets bumped to settle the rerun
+                // dependency; build.ninja must remain untouched.
+                static if(backend == "ninja")
+                    timeLastModified(inSandboxPath("build.ninja"))
+                        .shouldEqual(before);
+            }
+        }
+
         @("rerun.deleted.dir." ~ backend)
         @Tags(backend)
         unittest {
@@ -517,7 +564,10 @@ version(DigitalMars) {
                 else
                     static assert(false, "unknown backend");
 
-                mixin(backend).shouldFailToExecute.shouldNotContain(msg);
+                // instead of choking on the missing inputs, the rerun
+                // regenerates the build without the deleted directory
+                // and the build succeeds
+                mixin(backend).shouldExecuteOk.shouldNotContain(msg);
             }
         }
 

--- a/tests/main.d
+++ b/tests/main.d
@@ -3,6 +3,25 @@ import unit_threaded;
 int main(string[] args) {
     import unit_threaded.runner.runner: runTests;
 
+    // The integration tests run reggae in-process, so the build files
+    // they generate in sandboxes call back into this very binary to
+    // check whether reggae needs rerunning (in production it would be
+    // the actual reggae binary). Act like reggae's main in that case.
+    {
+        import std.algorithm: canFind;
+        if(args.canFind("--rerun-check")) {
+            import reggae.reggae: run;
+            import std.stdio: stdout, stderr;
+            try
+                run(stdout, args);
+            catch(Exception ex) {
+                stderr.writeln(ex.msg);
+                return 1;
+            }
+            return 0;
+        }
+    }
+
     primeDubBuild;
 
     return args.runTests!(


### PR DESCRIPTION
Editing an existing source file — e.g. an Emacs save, which renames a temporary file over the original and thereby bumps the parent directory's mtime — made make/ninja rerun reggae even though the build hadn't structurally changed. Reggae should only rerun when files are added or removed, or when the build description itself changes.

## How

The generated build files keep their mtime dependencies on reggae itself, the build description (reggaefile + its imports + dub files) and the source directories — those decide *when* the rerun command is invoked, exactly as before. What changed is *what* that command does: it is now `reggae --rerun-check`, which only regenerates the build when

* a build-description dependency is missing or newer than the generated build file, or
* the set of files in the source directories differs from the set recorded in `.reggae/rerun-state.json` when the build was generated.

Otherwise it prints "Build description unchanged, not rerunning reggae" and does nothing. For ninja, `restat = 1` on the `_rerun` rule lets build.ninja's unchanged mtime settle the trigger so the check doesn't run again on the next build; make has no restat equivalent, so the Makefile's timestamp is bumped instead.

The file-set comparison deliberately includes directory entries the build might not care about (editor backup files and the like): whether a file matters can only be known by running the build description, so the check over-approximates and reruns in that case — which is also what "rerun when a file is added" means.

## Test changes

* New `rerun.changed.file.{ninja,make}` tests model the editor save via a temp-file rename; the ninja variant also asserts `build.ninja`'s mtime is untouched.
* The test binary now acts as reggae's main when invoked with `--rerun-check`, because the integration tests run reggae in-process and the sandboxed build files call back into `bin/ut`. The rerun command therefore actually *works* in sandboxes now, so tests that previously asserted rerun-failure-as-a-proxy (`rerun.deleted.dir`, `reggaefile.imports`) assert the real behaviour instead: the rerun regenerates the build and the build succeeds (editing a module imported by the reggaefile really does produce the renamed executable, as the old test comment wished for).

## Verification

* Full `bin/ut` suite green locally (260 tests), `bootstrap.sh make` works.
* Manual end-to-end on a sandbox project: editor-save rename → one check run, no regeneration, `build.ninja` mtime identical, next ninja run is "no work to do"; adding or deleting a source file → full rerun with the file (dis)appearing from `build.ninja`; touching the reggaefile → full rerun.

Note: building reggae *itself* in the bootstrap layout still reruns reggae on every make. That's pre-existing behaviour on master (`bin/reggae` is both the rerun binary and a build output, and the generated dub config churns) and is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)