### PR TITLE
Rerun reggae when a dubPackage/dubDependant recipe changes

### DIFF
--- a/payload/reggae/backend/make.d
+++ b/payload/reggae/backend/make.d
@@ -75,7 +75,7 @@ struct Makefile {
     //includes rerunning reggae
     string output() @safe {
 
-        import reggae.backend: rerunCommand;
+        import reggae.backend: rerunCommand, extraRerunDependencies;
         import std.array: join;
         import std.range: chain;
         import std.algorithm: sort, uniq;
@@ -92,7 +92,7 @@ struct Makefile {
             // actually needs to be rerun, so that editing an existing
             // source file doesn't regenerate the build.
             auto srcDirs = _srcDirs.sort.uniq;
-            const flattenedInputs = chain(options.reggaeFileDependencies, srcDirs).join(" ");
+            const flattenedInputs = chain(options.reggaeFileDependencies, extraRerunDependencies, srcDirs).join(" ");
             const rerunLine = "\t" ~ rerunCommand(options) ~ "\n";
 
             ret ~= fileName() ~ ": " ~ flattenedInputs ~ "\n";

--- a/payload/reggae/backend/ninja.d
+++ b/payload/reggae/backend/ninja.d
@@ -43,13 +43,15 @@ struct Ninja {
         import std.range: chain, only;
 
         const(NinjaEntry)[] rerunEntries() {
+            import reggae.backend: extraRerunDependencies;
+
             // if exporting the build system, don't include rerunning reggae
             if(_options.export_)
                 return [];
 
             auto srcDirs = _srcDirs.sort.uniq;
             const flattenedInputs = flattenEntriesInBuildLine(
-                chain(_options.reggaeFileDependencies, srcDirs).array
+                chain(_options.reggaeFileDependencies, extraRerunDependencies, srcDirs).array
             );
             auto paramLines = _options.oldNinja ? [] : ["pool = console"];
 

--- a/payload/reggae/backend/package.d
+++ b/payload/reggae/backend/package.d
@@ -53,6 +53,25 @@ private auto trustedArray(R)(auto ref scope R rng) @trusted {
 
 private alias Options = imported!"reggae.options".Options;
 
+// Files read while computing the build description that
+// `Options.reggaeFileDependencies` knows nothing about, such as the
+// recipes of dub packages depended on via `dubPackage`/`dubDependant`.
+// Editing them changes the build description, so they need to trigger
+// a reggae rerun. Rules register them when the build description is
+// evaluated; the backends then write them to the generated build files
+// and to the rerun state (the rerun check runs in a separate process).
+private string[] gExtraRerunDeps;
+
+package(reggae) void registerRerunDependencies(in string[] paths...) @safe {
+    gExtraRerunDeps ~= paths;
+}
+
+package(reggae) string[] extraRerunDependencies() @safe {
+    import std.algorithm: sort, uniq;
+    import std.array: array;
+    return gExtraRerunDeps.dup.sort.uniq.array;
+}
+
 // What the generated build files run when any of the build
 // description's dependencies (including the source directories) is out
 // of date. `--rerun-check` only actually reruns reggae if the build
@@ -83,11 +102,11 @@ bool rerunIsNeeded(in Options options) @safe {
         return true;
 
     const buildFileTime = buildFile.timeLastModified;
-    foreach(dep; options.reggaeFileDependencies)
+    const state = readRerunState(options);
+    foreach(dep; options.reggaeFileDependencies ~ state.dependencies)
         if(!dep.exists || dep.timeLastModified > buildFileTime)
             return true;
 
-    const state = readRerunState(options);
     return scanSrcFiles(options.workingDir, state.srcDirs) != state.srcFiles;
 }
 
@@ -126,6 +145,7 @@ private string buildFilePath(in Options options) @safe pure {
 private struct RerunState {
     string[] srcDirs;
     string[] srcFiles;
+    string[] dependencies;
 }
 
 private string rerunStatePath(in Options options) @safe pure {
@@ -146,6 +166,7 @@ private RerunState readRerunState(in Options options) @safe {
     RerunState ret;
     ret.srcDirs = json.objectNoRef["srcDirs"].arrayNoRef.map!(a => a.str).array;
     ret.srcFiles = json.objectNoRef["srcFiles"].arrayNoRef.map!(a => a.str).array;
+    ret.dependencies = json.objectNoRef["dependencies"].arrayNoRef.map!(a => a.str).array;
     return ret;
 }
 
@@ -168,6 +189,7 @@ package void writeRerunState(in Options options, in string[] srcDirs) @safe {
     auto json = JSONValue([
         "srcDirs": JSONValue(sortedSrcDirs),
         "srcFiles": JSONValue(scanSrcFiles(options.workingDir, sortedSrcDirs)),
+        "dependencies": JSONValue(extraRerunDependencies),
     ]);
 
     auto file = File(statePath, "w");

--- a/payload/reggae/rules/dub/external.d
+++ b/payload/reggae/rules/dub/external.d
@@ -259,6 +259,25 @@ private struct DubPathDependency {
         // only really one key.
         auto output = () @trusted { return stdout; }();
         dubInfo = dubInfos(output, subOptions)[dubPath.config.value];
+
+        registerRecipeFiles;
+    }
+
+    // The targets derive from the recipes of the dub packages involved,
+    // which `Options.reggaeFileDependencies` knows nothing about, so
+    // register them to trigger a reggae rerun when they change.
+    private void registerRecipeFiles() {
+        import reggae.backend: registerRerunDependencies;
+        import std.file: exists;
+        import std.path: buildPath;
+
+        foreach(ref pkg; dubInfo.packages) {
+            foreach(fileName; ["dub.sdl", "dub.json", "package.json", "dub.selections.json"]) {
+                const path = buildPath(pkg.path, fileName);
+                if(path.exists)
+                    registerRerunDependencies(path);
+            }
+        }
     }
 
     Target target() {

--- a/tests/it/runtime/dub/dependencies.d
+++ b/tests/it/runtime/dub/dependencies.d
@@ -648,3 +648,120 @@ unittest {
         dur2.shouldBeSmallerThan((dur1 * 7) / 10);
     }
 }
+
+// Issue #301: editing the dub recipe of a package depended on via
+// dubPackage should rerun reggae so the build reflects the new recipe.
+@("dubPackage.path.rerun.recipe")
+@Tags("dub", "ninja")
+unittest {
+    with(immutable ReggaeSandbox()) {
+        writeFile(
+            "over/there/dub.sdl",
+            [
+                `name "foo"`,
+                `targetType "executable"`,
+            ]
+        );
+        writeFile(
+            "over/there/source/app.d",
+            q{
+                int main() {
+                    version(purple)
+                        return 0;
+                    else
+                        return 1;
+                }
+            }
+        );
+        writeFile(
+            "reggaefile.d",
+            q{
+                import reggae;
+                alias dubDep = dubPackage!(DubPath("over/there"));
+                mixin build!dubDep;
+            }
+        );
+
+        runReggae("-b", "ninja");
+        ninja.shouldExecuteOk;
+        shouldFail("over/there/foo");
+
+        // change the recipe so the package is compiled with -version=purple
+        writeFile(
+            "over/there/dub.sdl",
+            [
+                `name "foo"`,
+                `targetType "executable"`,
+                `versions "purple"`,
+            ]
+        );
+
+        ninja.shouldExecuteOk;
+        shouldSucceed("over/there/foo");
+    }
+}
+
+// Issue #301: editing the dub recipe of a package depended on via
+// dubDependant should rerun reggae so the build reflects the new recipe.
+@("dubDependant.ct.path.rerun.recipe")
+@MaybeFlaky
+@Tags("dub", "ninja")
+unittest {
+    with(immutable ReggaeSandbox()) {
+        writeFile(
+            "over/there/dub.sdl",
+            [
+                `name "foo"`,
+                `targetType "library"`,
+            ]
+        );
+        writeFile(
+            "over/there/source/foo.d",
+            q{
+                version(purple)
+                    int result() { return 0; }
+                else
+                    int result() { return 1; }
+            }
+        );
+        writeFile(
+            "src/app.d",
+            q{
+                import foo;
+                int main() {
+                    return result;
+                }
+            }
+        );
+        writeFile(
+            "reggaefile.d",
+            q{
+                import reggae;
+                alias app = dubDependant!(
+                    TargetName("myapp"),
+                    DubPackageTargetType.executable,
+                    Sources!(Files("src/app.d")),
+                    DubPath("over/there"),
+                );
+                mixin build!app;
+            }
+        );
+
+        runReggae("-b", "ninja");
+        ninja.shouldExecuteOk;
+        shouldFail("myapp");
+
+        // change the recipe so the dependency is compiled with -version=purple
+        writeFile(
+            "over/there/dub.sdl",
+            [
+                `name "foo"`,
+                `targetType "library"`,
+                `versions "purple"`,
+            ]
+        );
+
+        ninja.shouldExecuteOk;
+        shouldSucceed("myapp");
+    }
+}


### PR DESCRIPTION
Fixes #301.

The targets generated by the `dubPackage` and `dubDependant` rules derive from the recipes (`dub.sdl`/`dub.json`) of the dub packages involved, which are read when the build description is evaluated. Editing such a recipe therefore changes the build description, but nothing triggered a reggae rerun: `Options.reggaeFileDependencies` only knows about the main project's dub files, and the source directory tracking only notices files being added or removed.

`DubPathDependency` now registers the recipe files (including `dub.selections.json` where present) of every package in the resolved `DubInfo`. The ninja and make backends include them in the generated build files' rerun inputs, and they're persisted in `.reggae/rerun-state.json` so that `--rerun-check` (which runs in a separate process) can compare their timestamps against the build file. The binary backend needs no changes since it re-evaluates the build description on every invocation.

Written test-first: both new tests fail on master (the rebuilt binary still behaves per the old recipe) and pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)